### PR TITLE
날짜 등록시 년월일 형태로 받아서 LocalDateTime 형태로 변환하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/task/dto/TaskAddRequest.java
+++ b/app-server/src/main/java/com/growth/task/task/dto/TaskAddRequest.java
@@ -5,24 +5,29 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.growth.task.task.domain.Tasks;
 import com.growth.task.user.domain.Users;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 /**
  * Task 생성 요청
  */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TaskAddRequest {
     @NotNull(message = "user는 필수 입력 값입니다.")
     private Long userId;
     @NotNull(message = "테스크 날짜는 필수 입력 값입니다.")
-    private LocalDateTime taskDate;
+    @DateTimeFormat(pattern = "YYYY-MM-dd")
+    private LocalDate taskDate;
 
     @Builder
-    public TaskAddRequest(Long userId, LocalDateTime taskDate) {
+    public TaskAddRequest(Long userId, LocalDate taskDate) {
         this.userId = userId;
         this.taskDate = taskDate;
     }
@@ -30,7 +35,7 @@ public class TaskAddRequest {
     public Tasks toEntity(Users user) {
         return Tasks.builder()
                 .user(user)
-                .taskDate(taskDate)
+                .taskDate(taskDate.atStartOfDay())
                 .build();
     }
 }


### PR DESCRIPTION
- `2023-08-30` 형태로 생성 api 요청시, `LocalDateTime` 형태가 아니라 오류 발생
  - LocalDateTime 형식이면 `2023-08-30T00:00:00` 형태로 데이터가 날아와야 함
  - `TaskDate`의 의미는 그 테스크의 날짜만을 의미하기 때문에 시간을 받을 필요가 없다. 
  - 따라서 `2023-08-30` 형태로 받고 뒤에 시간은 시작 시간으로 파싱해서 넣도록 한다.  