### PR TITLE
테스크 리스트 조회를 리팩토링하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/task/repository/TasksRepositoryCustom.java
+++ b/app-server/src/main/java/com/growth/task/task/repository/TasksRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.growth.task.task.repository;
 
+import com.growth.task.task.dto.TaskListRequest;
 import com.growth.task.task.dto.TaskListWithTodoStatusResponse;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TasksRepositoryCustom {
-    List<TaskListWithTodoStatusResponse> findRemainedTodosByUserBetweenTimeRange(Long userId, LocalDateTime startDate, LocalDateTime endDate);
+    List<TaskListWithTodoStatusResponse> findRemainedTodosByUserBetweenTimeRange(TaskListRequest request);
 }

--- a/app-server/src/main/java/com/growth/task/task/repository/impl/TasksRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/task/repository/impl/TasksRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.growth.task.task.repository.impl;
 
+import com.growth.task.task.dto.TaskListRequest;
 import com.growth.task.task.dto.TaskListWithTodoStatusResponse;
 import com.growth.task.task.repository.TasksRepositoryCustom;
 import com.querydsl.core.types.Projections;
@@ -21,7 +22,11 @@ public class TasksRepositoryCustomImpl implements TasksRepositoryCustom {
     }
 
     @Override
-    public List<TaskListWithTodoStatusResponse> findRemainedTodosByUserBetweenTimeRange(Long userId, LocalDateTime startDate, LocalDateTime endDate) {
+    public List<TaskListWithTodoStatusResponse> findRemainedTodosByUserBetweenTimeRange(TaskListRequest request) {
+        Long userId = request.getUserId();
+        LocalDateTime startDate = request.getStartDate().atStartOfDay();
+        LocalDateTime endDate = request.getEndDate().atStartOfDay();
+
         return queryFactory.select(Projections.fields(TaskListWithTodoStatusResponse.class,
                         tasks.taskId,
                         tasks.user.userId.as("userId"),

--- a/app-server/src/main/java/com/growth/task/task/service/TaskListService.java
+++ b/app-server/src/main/java/com/growth/task/task/service/TaskListService.java
@@ -31,11 +31,7 @@ public class TaskListService {
 
     @Transactional(readOnly = true)
     public List<TaskListResponse> getTasks(TaskListRequest request) {
-        List<TaskListWithTodoStatusResponse> taskList = tasksRepository.findRemainedTodosByUserBetweenTimeRange(
-                request.getUserId(),
-                request.getStartDate().atStartOfDay(),
-                request.getEndDate().atStartOfDay()
-        );
+        List<TaskListWithTodoStatusResponse> taskList = tasksRepository.findRemainedTodosByUserBetweenTimeRange(request);
 
         Map<Long, TaskTodoResponse> groupingByTask = calculateTaskTodoStatusMap(taskList);
 

--- a/app-server/src/main/java/com/growth/task/task/service/TaskListService.java
+++ b/app-server/src/main/java/com/growth/task/task/service/TaskListService.java
@@ -9,6 +9,7 @@ import com.growth.task.todo.enums.Status;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +39,11 @@ public class TaskListService {
 
         Map<Long, TaskTodoResponse> groupingByTask = calculateTaskTodoStatusMap(taskList);
 
-        return collectToTask(taskList, groupingByTask);
+        List<TaskListResponse> taskListResponses = collectToTask(taskList, groupingByTask);
+
+        return taskListResponses.stream()
+                .sorted(byTaskDate())
+                .collect(toList());
     }
 
     /**
@@ -111,5 +116,9 @@ public class TaskListService {
             }
         }
         return new TaskTodoResponse(remainCount, doneCount);
+    }
+
+    private static Comparator<TaskListResponse> byTaskDate() {
+        return Comparator.comparing(TaskListResponse::getTaskDate);
     }
 }

--- a/app-server/src/test/java/com/growth/task/task/controller/TaskListControllerTest.java
+++ b/app-server/src/test/java/com/growth/task/task/controller/TaskListControllerTest.java
@@ -105,7 +105,6 @@ class TaskListControllerTest {
             params.add("userId", String.valueOf(request.getUserId()));
             params.add("startDate", String.valueOf(request.getStartDate()));
             params.add("endDate", String.valueOf(request.getEndDate()));
-            params.add("sort", "taskDate");
 
             return mockMvc.perform(get("/api/v1/tasks")
                     .params(params)

--- a/app-server/src/test/java/com/growth/task/task/repository/impl/TasksRepositoryCustomImplTest.java
+++ b/app-server/src/test/java/com/growth/task/task/repository/impl/TasksRepositoryCustomImplTest.java
@@ -2,11 +2,12 @@ package com.growth.task.task.repository.impl;
 
 import com.growth.task.config.TestQueryDslConfig;
 import com.growth.task.task.domain.Tasks;
+import com.growth.task.task.dto.TaskListRequest;
 import com.growth.task.task.dto.TaskListWithTodoStatusResponse;
 import com.growth.task.task.repository.TasksRepository;
 import com.growth.task.todo.domain.Todos;
-import com.growth.task.todo.repository.TodosRepository;
 import com.growth.task.todo.enums.Status;
+import com.growth.task.todo.repository.TodosRepository;
 import com.growth.task.user.domain.Users;
 import com.growth.task.user.domain.UsersRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -92,6 +93,8 @@ class TasksRepositoryCustomImplTest {
         @Nested
         @DisplayName("user id와 task_date 날짜 범위가 주어지면")
         class Context_with_user_id_and_task_date_range {
+            private TaskListRequest request;
+
             @BeforeEach
             void setContext() {
                 getTodo(task1, "디자인 패턴의 아름다움 읽기", Status.READY);
@@ -104,16 +107,17 @@ class TasksRepositoryCustomImplTest {
                 getTodo(task2, "파이썬 코딩의 기술 읽기", Status.DONE);
                 getTodo(task2, "Two Scoops of Django 읽기", Status.DONE);
                 getTodo(task3, "운동하기", Status.DONE);
+
+                request = TaskListRequest.builder().userId(user.getUserId())
+                        .startDate(LocalDate.from(task0.getTaskDate()))
+                        .endDate(LocalDate.from(task2.getTaskDate()))
+                        .build();
             }
 
             @Test
             @DisplayName("task 정보와 todo status를 반환한다")
             void it_return_task_info_and_todo_count() {
-                List<TaskListWithTodoStatusResponse> result = tasksRepository.findRemainedTodosByUserBetweenTimeRange(
-                        user.getUserId(),
-                        task0.getTaskDate(),
-                        task2.getTaskDate()
-                );
+                List<TaskListWithTodoStatusResponse> result = tasksRepository.findRemainedTodosByUserBetweenTimeRange(request);
 
                 assertAll(
                         () -> assertThat(result).hasSize(10),

--- a/app-server/src/test/java/com/growth/task/task/service/TaskListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/task/service/TaskListServiceTest.java
@@ -81,16 +81,12 @@ class TaskListServiceTest {
 
             @BeforeEach
             void prepare() {
-                given(tasksRepository.findRemainedTodosByUserBetweenTimeRange(
-                                request.getUserId(),
-                                request.getStartDate().atStartOfDay(),
-                                request.getEndDate().atStartOfDay()
-                        )
-                ).willReturn(List.of(
-                        new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo1.getStatus()),
-                        new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo2.getStatus()),
-                        new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo3.getStatus())
-                ));
+                given(tasksRepository.findRemainedTodosByUserBetweenTimeRange(request))
+                        .willReturn(List.of(
+                                new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo1.getStatus()),
+                                new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo2.getStatus()),
+                                new TaskListWithTodoStatusResponse(1L, 1L, givenTask.getTaskDate(), givenTodo3.getStatus())
+                        ));
             }
 
             @Test
@@ -288,7 +284,7 @@ class TaskListServiceTest {
             void it_return_task_list() {
                 List<TaskListResponse> result = collectToTask(taskList, groupingByTask);
                 assertAll(
-                        () ->assertThat(result).hasSize(4)
+                        () -> assertThat(result).hasSize(4)
                 );
             }
         }


### PR DESCRIPTION
- 리스트 조회 후 `taskDate` 기준으로 정렬 
- 리스트 조회시, `userId`, `startDate`, `endDate`를 넘기는 것이 아니라 TaskListRequest를 넘기도록 수정