### PR TITLE
Todo 및 Pomodoro API 리팩토링 및 문서화를 개선하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/pomodoro/controller/PomodoroUpdateController.java
+++ b/app-server/src/main/java/com/growth/task/pomodoro/controller/PomodoroUpdateController.java
@@ -4,6 +4,7 @@ import com.growth.task.pomodoro.domain.Pomodoros;
 import com.growth.task.pomodoro.dto.request.PomodoroUpdateRequest;
 import com.growth.task.pomodoro.dto.response.PomodoroUpdateResponse;
 import com.growth.task.pomodoro.service.PomodoroService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,6 +12,7 @@ import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping("/api/v1/pomodoros")
+@Tag(name = "Pomodoro", description = "Pomodoro API Document")
 public class PomodoroUpdateController {
 
     private final PomodoroService pomodoroService;

--- a/app-server/src/main/java/com/growth/task/pomodoro/dto/response/PomodoroUpdateResponse.java
+++ b/app-server/src/main/java/com/growth/task/pomodoro/dto/response/PomodoroUpdateResponse.java
@@ -1,6 +1,5 @@
 package com.growth.task.pomodoro.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.growth.task.pomodoro.domain.Pomodoros;
@@ -10,9 +9,7 @@ import lombok.Getter;
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PomodoroUpdateResponse {
-    @JsonProperty("perform_count")
     private int performCount;
-    @JsonProperty("plan_count")
     private int planCount;
 
     @Builder

--- a/app-server/src/main/java/com/growth/task/todo/controller/TodoAddController.java
+++ b/app-server/src/main/java/com/growth/task/todo/controller/TodoAddController.java
@@ -3,12 +3,14 @@ package com.growth.task.todo.controller;
 import com.growth.task.todo.application.TodoAddService;
 import com.growth.task.todo.dto.composite.TodoAndPomodoroAddRequest;
 import com.growth.task.todo.dto.composite.TodoAndPomodoroAddResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/todos")
+@Tag(name = "Todo", description = "Todo API Document")
 public class TodoAddController {
 
     private final TodoAddService todoAddService;

--- a/app-server/src/main/java/com/growth/task/todo/controller/TodoDeleteController.java
+++ b/app-server/src/main/java/com/growth/task/todo/controller/TodoDeleteController.java
@@ -1,12 +1,14 @@
 package com.growth.task.todo.controller;
 
 import com.growth.task.todo.application.TodoDeleteService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @RestController
 @RequestMapping("/api/v1/todos")
+@Tag(name = "Todo", description = "Todo API Document")
 public class TodoDeleteController {
 
     private final TodoDeleteService todoDeleteService;

--- a/app-server/src/main/java/com/growth/task/todo/controller/TodoDeleteController.java
+++ b/app-server/src/main/java/com/growth/task/todo/controller/TodoDeleteController.java
@@ -15,7 +15,7 @@ public class TodoDeleteController {
         this.todoDeleteService = todoDeleteService;
     }
 
-    @PostMapping("/{todo_id}")
+    @DeleteMapping("/{todo_id}")
     @ResponseStatus(NO_CONTENT)
     public void delete(@PathVariable("todo_id") Long todoId) {
         todoDeleteService.deleteByTodoId(todoId);

--- a/app-server/src/main/java/com/growth/task/todo/controller/TodoListController.java
+++ b/app-server/src/main/java/com/growth/task/todo/controller/TodoListController.java
@@ -2,6 +2,7 @@ package com.growth.task.todo.controller;
 
 import com.growth.task.todo.application.TodoListService;
 import com.growth.task.todo.dto.response.TodoListResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/todos")
+@Tag(name = "Todo", description = "Todo API Document")
 public class TodoListController {
 
     private final TodoListService todoListService;

--- a/app-server/src/main/java/com/growth/task/todo/controller/TodoUpdateController.java
+++ b/app-server/src/main/java/com/growth/task/todo/controller/TodoUpdateController.java
@@ -4,6 +4,7 @@ import com.growth.task.todo.application.TodoService;
 import com.growth.task.todo.domain.Todos;
 import com.growth.task.todo.dto.request.TodoUpdateRequest;
 import com.growth.task.todo.dto.response.TodoUpdateResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,6 +12,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping("/api/v1/todos")
+@Tag(name = "Todo", description = "Todo API Document")
 public class TodoUpdateController {
 
     private final TodoService todoService;

--- a/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddResponse.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddResponse.java
@@ -35,15 +35,4 @@ public class TodoAndPomodoroAddResponse {
         this.performCount = pomodoroAddResponse.getPerformCount();
         this.planCount = pomodoroAddResponse.getPlanCount();
     }
-
-    public static TodoAndPomodoroAddResponse from(TodoAddResponse todoResponse, PomodoroAddResponse pomodoroResponse) {
-        return TodoAndPomodoroAddResponse.builder()
-                .todoId(todoResponse.getTodoId())
-                .taskId(todoResponse.getTaskId())
-                .todo(todoResponse.getTodo())
-                .status(todoResponse.getStatus().toString())
-                .performCount(pomodoroResponse.getPerformCount())
-                .planCount(pomodoroResponse.getPlanCount())
-                .build();
-    }
 }

--- a/app-server/src/main/java/com/growth/task/todo/dto/request/TodoUpdateRequest.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/request/TodoUpdateRequest.java
@@ -2,10 +2,7 @@ package com.growth.task.todo.dto.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.growth.task.task.domain.Tasks;
-import com.growth.task.todo.domain.Todos;
 import com.growth.task.todo.enums.Status;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/app-server/src/main/java/com/growth/task/todo/dto/response/TodoListResponse.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/response/TodoListResponse.java
@@ -1,22 +1,20 @@
 package com.growth.task.todo.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.growth.task.pomodoro.domain.Pomodoros;
 import com.growth.task.todo.domain.Todos;
 import com.growth.task.todo.enums.Status;
 import lombok.Getter;
 
 @Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TodoListResponse {
-    @JsonProperty("todo_id")
     private Long todoId;
-    @JsonProperty("task_id")
     private Long taskId;
     private String todo;
     private Status status;
-    @JsonProperty("perform_count")
     private Integer performCount;
-    @JsonProperty("plan_count")
     private Integer planCount;
 
     public TodoListResponse(Long todoId, Long taskId, String todo, Status status, Integer performCount, Integer planCount) {

--- a/app-server/src/main/java/com/growth/task/todo/dto/response/TodoUpdateResponse.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/response/TodoUpdateResponse.java
@@ -1,6 +1,5 @@
 package com.growth.task.todo.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.growth.task.todo.domain.Todos;
@@ -14,9 +13,7 @@ import lombok.Getter;
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TodoUpdateResponse {
-    @JsonProperty("todo_id")
     private Long todoId;
-    @JsonProperty("task_id")
     private Long taskId;
     private String todo;
     private Status status;


### PR DESCRIPTION
본 PR에서는 다음 변경 사항들을 반영하였습니다:

1. Todo 삭제 API 의 메서드를 POST 에서 DELETE 로 변경하였습니다.
2. TodoAndPomodoroAddResponse 에서 불필요한 메서드를 삭제하였습니다.
3. 사용하지 않는 import 문을 제거하였습니다.
4. `@JsonProperty` 로 직접 정의하던 필드명을 `@JsonNaming` 을 사용하여 snake_case 로 통일하였습니다.
5. Todo 및 Pomodoro API 문서화를 위해 @Tag 애노테이션을 추가하여 설명 및 태그명을 명시하였습니다.

리뷰 부탁드립니다.
