### PR TITLE
EC2 DB 접속 정보를 설정하라

### DIFF
--- a/app-server/src/main/resources/application.yml
+++ b/app-server/src/main/resources/application.yml
@@ -1,5 +1,12 @@
 spring:
+  datasource:
+    url: jdbc:mariadb://3.39.23.180:3306/taskgrow
+    username: root
+    password: 1234
+    driver-class-name: org.mariadb.jdbc.Driver
   jpa:
+    hibernate:
+      ddl-auto: validate
     show_sql: true
     properties:
       hibernate:


### PR DESCRIPTION
EC2 인스턴스에 docker로 마리아DB를 띄웠다. 
스프링 부트 `application.yml` 설정에 DB 설정을 했다. 

프로필을 나눠서, 로컬에서는 EC2 인스턴스 DB를 향하지 않도록 분리가 필요하다.