### PR TITLE
[Backend] 회고를 수정할 수 있다 #135

### DIFF
--- a/app-server/src/main/java/com/growth/task/review/controller/ReviewUpdateController.java
+++ b/app-server/src/main/java/com/growth/task/review/controller/ReviewUpdateController.java
@@ -1,0 +1,39 @@
+package com.growth.task.review.controller;
+
+import com.growth.task.review.domain.Review;
+import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewUpdateRequest;
+import com.growth.task.review.service.ReviewUpdateService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/api/v1/review")
+@Tag(name = "Review", description = "회고 API")
+public class ReviewUpdateController {
+    private final ReviewUpdateService reviewUpdateService;
+
+    public ReviewUpdateController(ReviewUpdateService reviewUpdateService) {
+        this.reviewUpdateService = reviewUpdateService;
+    }
+
+    @PutMapping("/{review_id}")
+    @ResponseStatus(OK)
+    public ReviewDetailResponse update(
+            @PathVariable("review_id") Long reviewId,
+            @RequestBody @Valid ReviewUpdateRequest request
+    ) {
+        Review review = reviewUpdateService.update(reviewId, request);
+        return new ReviewDetailResponse(review);
+    }
+}

--- a/app-server/src/main/java/com/growth/task/review/domain/Review.java
+++ b/app-server/src/main/java/com/growth/task/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.growth.task.review.domain;
 
 import com.growth.task.commons.domain.BaseTimeEntity;
+import com.growth.task.review.dto.ReviewUpdateRequest;
 import com.growth.task.review.exception.OutOfBoundsException;
 import com.growth.task.task.domain.Tasks;
 import jakarta.persistence.Column;
@@ -58,5 +59,11 @@ public class Review extends BaseTimeEntity {
 
     private static boolean isBetween(Integer value, int lower, int upper) {
         return value >= lower && value <= upper;
+    }
+
+    public void update(ReviewUpdateRequest request) {
+        validFeelingsScore(request.getFeelingsScore());
+        this.feelingsScore = request.getFeelingsScore();
+        this.contents = request.getContents();
     }
 }

--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewUpdateRequest.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.growth.task.review.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ReviewUpdateRequest {
+    @NotBlank(message = "회고 내용을 입력해주세요.")
+    private String contents;
+    @Min(value = 1, message = "기분점수는 1~10 사이로 입력해주세요.")
+    @Max(value = 10, message = "기분점수는 1~10 사이로 입력해주세요.")
+    private Integer feelingsScore;
+
+    public ReviewUpdateRequest(String contents, Integer feelingsScore) {
+        this.contents = contents;
+        this.feelingsScore = feelingsScore;
+    }
+}

--- a/app-server/src/main/java/com/growth/task/review/service/ReviewUpdateService.java
+++ b/app-server/src/main/java/com/growth/task/review/service/ReviewUpdateService.java
@@ -1,0 +1,24 @@
+package com.growth.task.review.service;
+
+import com.growth.task.review.domain.Review;
+import com.growth.task.review.dto.ReviewUpdateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class ReviewUpdateService {
+    private final ReviewDetailService reviewDetailService;
+
+    public ReviewUpdateService(ReviewDetailService reviewDetailService) {
+        this.reviewDetailService = reviewDetailService;
+    }
+
+    @Transactional
+    public Review update(Long reviewId, ReviewUpdateRequest request) {
+        Review review = reviewDetailService.findReviewById(reviewId);
+
+        review.update(request);
+        return review;
+    }
+}

--- a/app-server/src/test/java/com/growth/task/review/controller/ReviewUpdateControllerTest.java
+++ b/app-server/src/test/java/com/growth/task/review/controller/ReviewUpdateControllerTest.java
@@ -1,0 +1,157 @@
+package com.growth.task.review.controller;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.growth.task.review.domain.Review;
+import com.growth.task.review.dto.ReviewUpdateRequest;
+import com.growth.task.review.service.ReviewRepository;
+import com.growth.task.task.domain.Tasks;
+import com.growth.task.task.repository.TasksRepository;
+import com.growth.task.user.domain.Users;
+import com.growth.task.user.domain.UsersRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("ReviewUpdateController")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ReviewUpdateControllerTest {
+    public static final String CONTENTS = "테스트를 작성하였다. 기분이 좋다";
+    public static final String NEW_CONTENTS = "회고 내용을 수정했습니다.";
+    public static final int NEW_FEELINGS_SCORE = 7;
+    @Autowired
+    private ReviewRepository reviewRepository;
+    @Autowired
+    private UsersRepository usersRepository;
+    @Autowired
+    private TasksRepository tasksRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+        objectMapper.registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        reviewRepository.deleteAll();
+        tasksRepository.deleteAll();
+        usersRepository.deleteAll();
+    }
+
+    private Users getUser(String name, String password) {
+        return usersRepository.save(
+                Users.builder()
+                        .name(name)
+                        .password(password)
+                        .build()
+        );
+    }
+
+    private Tasks getTask(Users user, LocalDate taskDate) {
+        return tasksRepository.save(
+                Tasks.builder()
+                        .taskDate(taskDate)
+                        .user(user)
+                        .build()
+        );
+    }
+
+    private Review getReview(Tasks tasks, String contents, int feelingsScore) {
+        return reviewRepository.save(
+                Review.builder()
+                        .tasks(tasks)
+                        .contents(contents)
+                        .feelingsScore(feelingsScore)
+                        .build()
+        );
+    }
+
+    @DisplayName("Review 수정 PUT 요청은")
+    @Nested
+    class Describe_PUT {
+        private ResultActions subject(Long reviewId, ReviewUpdateRequest request) throws Exception {
+            return mockMvc.perform(put("/api/v1/review/{reviewId}", reviewId)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+        }
+
+        @Nested
+        @DisplayName("존재하는 Review id가 주어지면")
+        class Context_with_exist_review_id {
+            private Review review;
+            private final ReviewUpdateRequest request = new ReviewUpdateRequest(NEW_CONTENTS, NEW_FEELINGS_SCORE);
+
+            @BeforeEach
+            void prepare() {
+                Users user = getUser("grow", "password");
+                Tasks task = getTask(user, LocalDate.of(2023, 10, 26));
+                review = getReview(task, CONTENTS, 7);
+            }
+
+            @Test
+            @DisplayName("id에 해당하는 회고를 수정하고 200을 응답한다")
+            void it_response_200() throws Exception {
+                ResultActions resultActions = subject(review.getId(), request);
+                resultActions.andExpect(status().isOk())
+                        .andExpect(jsonPath("contents").value(NEW_CONTENTS))
+                        .andExpect(jsonPath("feelings_score").value(NEW_FEELINGS_SCORE))
+                ;
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 Review id가 주어지면")
+        class Context_with_not_exist_review_id {
+            private Review review;
+            private final ReviewUpdateRequest request = new ReviewUpdateRequest(NEW_CONTENTS, NEW_FEELINGS_SCORE);
+
+            @BeforeEach
+            void prepare() {
+                Users user = getUser("grow", "password");
+                Tasks task = getTask(user, LocalDate.of(2023, 10, 26));
+                review = getReview(task, CONTENTS, 7);
+                reviewRepository.deleteById(review.getId());
+            }
+
+            @Test
+            @DisplayName("404을 응답한다")
+            void it_response_404() throws Exception {
+                ResultActions resultActions = subject(review.getId(), request);
+                resultActions.andExpect(status().isNotFound())
+                ;
+            }
+        }
+    }
+}

--- a/app-server/src/test/java/com/growth/task/review/domain/ReviewTest.java
+++ b/app-server/src/test/java/com/growth/task/review/domain/ReviewTest.java
@@ -1,0 +1,37 @@
+package com.growth.task.review.domain;
+
+import com.growth.task.review.exception.OutOfBoundsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Review")
+class ReviewTest {
+    @Test
+    @DisplayName("1~10 사이의 숫자가 주어지면 회고를 생성한다")
+    void createReview() {
+        Review review = Review.builder()
+                .contents("회고를 작성합니다.")
+                .feelingsScore(3)
+                .build();
+
+        assertThat(review).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 11})
+    @DisplayName("1~10사이가 아닌 경우 예외가 발생한다")
+    void outBoundFeelingScoreReviewCreate(int score) {
+        Executable when = () -> Review.builder()
+                .contents("회고를 작성합니다.")
+                .feelingsScore(score)
+                .build();
+
+        assertThrows(OutOfBoundsException.class, when);
+    }
+}

--- a/app-server/src/test/java/com/growth/task/review/service/ReviewUpdateServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/review/service/ReviewUpdateServiceTest.java
@@ -1,0 +1,90 @@
+package com.growth.task.review.service;
+
+import com.growth.task.review.domain.Review;
+import com.growth.task.review.dto.ReviewUpdateRequest;
+import com.growth.task.review.exception.ReviewNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReviewUpdateService")
+class ReviewUpdateServiceTest {
+    public static final String CONTENTS = "회고를 작성했습니다.";
+    public static final int FEELINGS_SCORE = 5;
+    public static final long REVIEW_ID = 1L;
+    public static final String NEW_CONTENTS = "회고 내용을 수정했습니다.";
+    public static final int NEW_FEELINGS_SCORE = 7;
+    private ReviewUpdateService reviewUpdateService;
+    @Mock
+    private ReviewDetailService reviewDetailService;
+
+    @BeforeEach
+    void setUp() {
+        reviewUpdateService = new ReviewUpdateService(reviewDetailService);
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Describe_update {
+        @Nested
+        @DisplayName("존재하는 회고의 아이디와 회고 내용, 기분점수가 주어지면")
+        class Context_with_exist_review_and_content_and_feeling_score {
+            private final Review review = Review.builder()
+                    .contents(CONTENTS)
+                    .feelingsScore(FEELINGS_SCORE)
+                    .build();
+
+            private final ReviewUpdateRequest request = new ReviewUpdateRequest(NEW_CONTENTS, NEW_FEELINGS_SCORE);
+
+            @BeforeEach
+            void prepare() {
+                ReflectionTestUtils.setField(review, "id", REVIEW_ID);
+                given(reviewDetailService.findReviewById(REVIEW_ID))
+                        .willReturn(review);
+            }
+
+            @Test
+            @DisplayName("내용과 기분점수를 업데이트한다")
+            void update_content_and_feeling_score() {
+                Review actual = reviewUpdateService.update(REVIEW_ID, request);
+
+                assertAll(
+                        () -> assertThat(actual.getContents()).isEqualTo(NEW_CONTENTS),
+                        () -> assertThat(actual.getFeelingsScore()).isEqualTo(NEW_FEELINGS_SCORE)
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회고 아이디가 주어지면")
+        class Context_with_not_exist_review_id {
+            private final Long invalidId = 0L;
+            private final ReviewUpdateRequest request = new ReviewUpdateRequest(NEW_CONTENTS, NEW_FEELINGS_SCORE);
+
+            @BeforeEach
+            void prepare() {
+                given(reviewDetailService.findReviewById(invalidId))
+                        .willThrow(ReviewNotFoundException.class);
+            }
+
+            @Test
+            @DisplayName("찾을 수 없다는 예외를 던진다")
+            void it_return_review() {
+                Executable when = () -> reviewUpdateService.update(invalidId, request);
+                assertThrows(ReviewNotFoundException.class, when);
+            }
+        }
+    }
+}


### PR DESCRIPTION
issue no. #135 

회고를 수정한다. 
PUT 요청으로 내용과 기분점수를 수정한다. 
PUT 방식이기 때문에, 내용만 수정할 때는 수정된 내용과 기존의 기본점수를 요청에 담아 넘겨야한다. 