### PR TITLE
[Frontend] 회고 아무것도 입력 안한 상태에서 삭제 누르면 에러메시지가 뜸

### DIFF
--- a/app-client/src/components/Review/UserReview.tsx
+++ b/app-client/src/components/Review/UserReview.tsx
@@ -118,9 +118,11 @@ const UserReview = () => {
     <>
       <Review value={inputValue} onChange={handleInputChange}></Review>
       <ButtonBox>
-        <Button onClick={handleDeleteReview} style={{ margin: '0 1rem' }}>
-          <BsTrash3 />
-        </Button>
+        {reviewId !== 0 && (
+          <Button onClick={handleDeleteReview} style={{ margin: '0 1rem' }}>
+            <BsTrash3 />
+          </Button>
+        )}
         <Button onClick={handleAddReview}>
           <BsCheckCircleFill />
         </Button>

--- a/app-client/src/services/review.ts
+++ b/app-client/src/services/review.ts
@@ -24,8 +24,7 @@ export const addReview = async (reviewData: AddReview) => {
       return review.data;
     }
   } catch (error: any) {
-    const errorMessage =
-      error.response.data.feelingsScore || error.response.data.contents;
+    const errorMessage = error.response.data.errors[0].reason;
 
     if (error.response.status === 409) {
       alert('하루에 하나의 회고만 작성할 수 있습니다.');
@@ -48,7 +47,9 @@ export const getReview = async (taskId: number) => {
 
 export const deleteReview = async (reviewId: number) => {
   try {
-    const isDelete = await axios.delete(`/api/v1/review/${reviewId}`);
+    const isDelete = await axios.delete(
+      `/httpClient/api/v1/review/${reviewId}`,
+    );
     return isDelete.status === 204;
   } catch (error: any) {
     alert('오류가 발생했습니다. 관리자에게 문의해주세요.');


### PR DESCRIPTION
issue no. #164 

<img width="537" alt="image" src="https://github.com/growth-ring/taskgrow/assets/116357790/4db6d9c9-842e-4afa-b318-a8394b18e413">

회고 미입력시 삭제 버튼이 뜨지 않도록 수정했습니다.