### PR TITLE
push에만 action이 돌도록 pull request에서 client path를 제거하라

### DIFF
--- a/.github/workflows/client-CI.yml
+++ b/.github/workflows/client-CI.yml
@@ -8,7 +8,6 @@ on:
       - '.github/workflows/client-CI.yml'
   pull_request:
     paths:
-      - 'app-client/**'
       - '.github/workflows/client-CI.yml'
 
 defaults:


### PR DESCRIPTION
pull request에 app-client 경로가 포함되어서 CD가 돔.
따라서, push의 경우에만 빌드 되도록 해당 path를 제거 