### PR TITLE
[Frontend] 타이머 시간이 제대로 작동하도록 하라

### DIFF
--- a/app-client/src/components/Pomodoro/Pomodoro.tsx
+++ b/app-client/src/components/Pomodoro/Pomodoro.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { TimerState } from '../../store/timer';
 
@@ -34,50 +33,11 @@ const BackContainer = styled.div`
 `;
 
 interface PomodoroProps {
-  time: number;
-  startTime: number;
+  percentage: number;
   timerState: TimerState;
 }
 
-function Pomodoro({ timerState, time, startTime }: PomodoroProps) {
-  const [percentage, setPercentage] = useState<number>(0);
-  const [animationFrameId, setAnimationFrameId] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (timerState !== 'RUNNING') {
-      if (animationFrameId !== null) {
-        cancelAnimationFrame(animationFrameId);
-        setAnimationFrameId(null);
-        setPercentage(0);
-      }
-      return;
-    }
-
-    const animationDuration: number = time * 60 * 1000;
-
-    const animate = () => {
-      const currentTime = Date.now();
-      const elapsedTime = currentTime - startTime;
-
-      if (elapsedTime < animationDuration) {
-        setPercentage((elapsedTime / animationDuration) * 100);
-        setAnimationFrameId(requestAnimationFrame(animate));
-      } else {
-        setPercentage(100);
-      }
-    };
-
-    if (animationFrameId === null) {
-      setAnimationFrameId(requestAnimationFrame(animate));
-    }
-
-    return () => {
-      if (animationFrameId !== null) {
-        cancelAnimationFrame(animationFrameId);
-      }
-    };
-  }, [timerState, animationFrameId]);
-
+function Pomodoro({ timerState, percentage }: PomodoroProps) {
   return (
     <>
       {(timerState === 'INITIAL' || timerState === 'FINISHED') && (

--- a/app-client/src/components/Pomodoro/Timer.tsx
+++ b/app-client/src/components/Pomodoro/Timer.tsx
@@ -1,9 +1,5 @@
-import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { TimerState } from '../../store/timer';
-import { useTimerStore } from '../../store/timer';
-import { useTodosStore } from '../../store/todos';
-import { updatePerformPomodoro } from '../../services/todo';
 
 const Time = styled.div`
   color: var(--main-color);
@@ -15,46 +11,12 @@ const Time = styled.div`
 interface TimerProps {
   time: number;
   timerState: TimerState;
+  isBreak: boolean;
 }
 
-const Timer = ({ time, timerState }: TimerProps) => {
-  const USER_TIME = time * 60 * 1000;
-  const INTERVAL = 1000;
-  const [timerTime, setTimerTime] = useState<number>(USER_TIME);
-  const { complete } = useTimerStore();
-  const { todoId, selectedTodo, isTodoChange, setIsTodoChange } =
-    useTodosStore();
-
-  const minute = String(Math.floor((timerTime / (1000 * 60)) % 60)).padStart(
-    2,
-    '0',
-  );
-  const second = String(Math.floor((timerTime / 1000) % 60)).padStart(2, '0');
-
-  useEffect(() => {
-    if (timerState === 'INITIAL') {
-      setTimerTime(USER_TIME);
-    }
-
-    if (timerState === 'RUNNING') {
-      const timer = setInterval(() => {
-        setTimerTime((prevTime) => prevTime - INTERVAL);
-      }, INTERVAL);
-
-      if (timerTime <= 0) {
-        clearInterval(timer);
-        complete();
-        updatePerformPomodoro(todoId).then(() =>
-          setIsTodoChange(!isTodoChange),
-        );
-      }
-      return () => {
-        clearInterval(timer);
-      };
-    }
-  }, [time, timerState, timerTime]);
-
-  const isBreak: boolean = selectedTodo === '휴식';
+const Timer = ({ time, timerState, isBreak }: TimerProps) => {
+  const minute = String(Math.floor((time / (1000 * 60)) % 60)).padStart(2, '0');
+  const second = String(Math.floor((time / 1000) % 60)).padStart(2, '0');
 
   return (
     <>


### PR DESCRIPTION
issue no. #165 

기존에는 
- 타이머 : `setInterval`함수 이용한 호출 스케일링
- 뽀모도로 : `requestAnimationFrame`함수 이용

**버그 구현 방법**
뽀모도로 시작후 타이머가 어느순간부터 1초가 2~3초씩 느려짐
뽀모도로가 끝나면 타이머가 제상태로 돌아옴

**버그 발생 원인**
`setInterval`은 지연 간격을 보장되지 않아 정확도가 떨어짐
함수를 실행시키는데  소모되는 시간이 명시한 지연 간격보다 길 때 실행이 종료될 때까지 기다려줌

**해결 방법**
우선 빠르게 대응하고자 타이머도 `requestAnimationFrame`함수를 이용하여 밀림 현상 방지