### PR TITLE
[Backend] 디비 비번 빼놓기#187

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !app-server/gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+app-server/src/main/resources/application-db.yml
 
 ### STS ###
 .apt_generated

--- a/app-server/src/main/resources/application-dev.yml
+++ b/app-server/src/main/resources/application-dev.yml
@@ -10,11 +10,11 @@ spring:
         true
       force:
         true
-  datasource:
-    url: jdbc:mariadb://13.125.177.52:3306/taskgrow
-    username: root
-    password: 1234
-    driver-class-name: org.mariadb.jdbc.Driver
+  #  datasource:
+  #    url: jdbc:mariadb://13.125.177.52:3306/taskgrow
+  #    username: root
+  #    password: 1234
+  #    driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: validate
@@ -22,6 +22,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  profiles:
+    include: db
 logging:
   level:
     org:


### PR DESCRIPTION
issue no. #187

디비 설정 정보를 따로 설정 파일로 빼놓고 git에 올라가지 않도록 처리. 
인스턴스 인바운드 규칙은 앱에서 접근할 때 문제로 인해 일단 ssh 접속만 막아두고 나머진 열어두었다.