### PR TITLE
[Backend] 사용자 아이디와 시간 범위에 따른 ToDo 조회 쿼리에서 User 조인을 제거하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
@@ -1,8 +1,8 @@
 package com.growth.task.todo.repository.impl;
 
 import com.growth.task.task.dto.TaskTodoDetailResponse;
-import com.growth.task.todo.dto.TodoStatsRequest;
 import com.growth.task.todo.dto.TodoResponse;
+import com.growth.task.todo.dto.TodoStatsRequest;
 import com.growth.task.todo.enums.Status;
 import com.growth.task.todo.repository.TodosRepositoryCustom;
 import com.querydsl.core.types.Projections;
@@ -16,7 +16,6 @@ import java.util.List;
 import static com.growth.task.pomodoro.domain.QPomodoros.pomodoros;
 import static com.growth.task.task.domain.QTasks.tasks;
 import static com.growth.task.todo.domain.QTodos.todos;
-import static com.growth.task.user.domain.QUsers.users;
 
 @Repository
 public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
@@ -56,15 +55,17 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
                 ))
                 .from(todos)
                 .leftJoin(tasks)
-                .on(todos.task.taskId.eq(tasks.taskId))
-                .leftJoin(users)
-                .on(tasks.user.userId.eq(users.userId))
+                .on(todos.task.eq(tasks))
                 .where(
-                        users.userId.eq(userId),
+                        eqUserId(userId),
                         betweenTimeRange(request)
                 )
                 .fetch()
                 ;
+    }
+
+    private static BooleanExpression eqUserId(Long userId) {
+        return tasks.user.userId.eq(userId);
     }
 
     private static BooleanExpression betweenTimeRange(TodoStatsRequest request) {


### PR DESCRIPTION
Todo 조회 쿼리 개선 

기존 
- 사용자 Id 필터를 사용자를 조인걸어서 필터 

바뀐 후 
- taks 테이블의 user로 조인 