### PR TITLE
[Backend] 배포시 DB 접속 에러 문제

### DIFF
--- a/.github/workflows/server-CI.yml
+++ b/.github/workflows/server-CI.yml
@@ -30,8 +30,8 @@ jobs:
         
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: gradle Assemble
-      run: ./gradlew assemble
+    - name: gradle Build
+      run: ./gradlew build
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/app-server/src/main/resources/application-dev.yml
+++ b/app-server/src/main/resources/application-dev.yml
@@ -10,17 +10,18 @@ spring:
         true
       force:
         true
-    datasource:
-      url: jdbc:mariadb://13.125.177.52:3306/taskgrow
-      username: root
-      password: taskgrow
-      driver-class-name: org.mariadb.jdbc.Driver
+  datasource:
+    url: jdbc:mariadb://13.125.177.52:3306/taskgrow
+    username: taskgrow
+    password: taskgrow
+    driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: validate
     show_sql: true
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MariaDB103Dialect
         format_sql: true
 logging:
   level:


### PR DESCRIPTION
자동 CI 배포시 DB 접속 에러 문제가 발생 

정확한 원인은 아직 파악이 안됐다.
에러 메세지로 봤을때는 권한 문제인거 같아서 새로운 계정을 만들고 그 계정으로 접속하도록 변경. 
그 후에도 되지 않아서 빌드 파일을 제거하고 `bootjar`로 다시 재 빌드 후 배포하니 성공 

CI 명령어가 원래 assemble 이었으나 build로 수정 bootJar는 테스트 실행, 코드 적용 범위, 정적 코드 분석, 수명주기 check 등을 하지 않기때문에 build로 결정 
이 때문에 안되기도 한다고 하는데 DB연결과 무슨 상관인지... 