### PR TITLE
[Backend] 사용자 감정 통계 상세 리스트를 조회하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/mypage/controller/MyPageController.java
+++ b/app-server/src/main/java/com/growth/task/mypage/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package com.growth.task.mypage.controller;
 
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
+import com.growth.task.review.dto.ReviewListRequest;
 import com.growth.task.review.dto.ReviewStatsRequest;
 import com.growth.task.review.dto.ReviewStatsResponse;
 import com.growth.task.review.service.ReviewListService;
@@ -21,6 +23,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping("/api/v1/mypage/{user_id}")
@@ -65,5 +71,14 @@ public class MyPageController {
             @ModelAttribute @Valid ReviewStatsRequest request
     ){
         return reviewListService.getReviewStats(userId, request);
+    }
+    @GetMapping("/review")
+    @ResponseStatus(OK)
+    public Page<ReviewDetailWithTaskDateResponse> getReviewByUserId(
+            @PageableDefault(size = 10) Pageable pageable,
+            @PathVariable("user_id") Long userId,
+            @ModelAttribute @Valid ReviewListRequest request
+    ) {
+        return reviewListService.getReviewByUserIdAndParams(pageable, userId, request);
     }
 }

--- a/app-server/src/main/java/com/growth/task/mypage/controller/MyPageController.java
+++ b/app-server/src/main/java/com/growth/task/mypage/controller/MyPageController.java
@@ -72,6 +72,7 @@ public class MyPageController {
     ){
         return reviewListService.getReviewStats(userId, request);
     }
+    @Operation(summary = "사용자 회고 통계 세부 리스트")
     @GetMapping("/review")
     @ResponseStatus(OK)
     public Page<ReviewDetailWithTaskDateResponse> getReviewByUserId(

--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewDetailWithTaskDateResponse.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewDetailWithTaskDateResponse.java
@@ -10,6 +10,9 @@ import java.time.LocalDate;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor
 @Getter
-public class ReviewDetailWithTaskDateResponse extends ReviewDetailResponse {
+public class ReviewDetailWithTaskDateResponse {
+    private Long reviewId;
+    private String subject;
+    private Integer feelingsScore;
     private LocalDate taskDate;
 }

--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewDetailWithTaskDateResponse.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewDetailWithTaskDateResponse.java
@@ -1,0 +1,15 @@
+package com.growth.task.review.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor
+@Getter
+public class ReviewDetailWithTaskDateResponse extends ReviewDetailResponse {
+    private LocalDate taskDate;
+}

--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
@@ -1,0 +1,36 @@
+package com.growth.task.review.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class ReviewListRequest {
+    private static final String FEELINGS_SCORE_VALID_MESSAGE = "기분 점수는 1 ~ 10 사이를 입력해주세요.";
+
+    @Min(value = 1, message = FEELINGS_SCORE_VALID_MESSAGE)
+    @Max(value = 10, message = FEELINGS_SCORE_VALID_MESSAGE)
+    private Integer feelingsScore;
+    @DateTimeFormat(pattern = "YYYY-MM-dd")
+    private LocalDate startDate;
+    @DateTimeFormat(pattern = "YYYY-MM-dd")
+    private LocalDate endDate;
+
+    @Builder
+    public ReviewListRequest(
+            Integer feelings_score,
+            LocalDate start_date,
+            LocalDate end_date
+    ) {
+        this.feelingsScore = feelings_score;
+        this.startDate = start_date;
+        this.endDate = end_date;
+    }
+}

--- a/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
@@ -1,10 +1,16 @@
 package com.growth.task.review.repository;
 
 import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
 import com.growth.task.review.dto.ReviewStatsRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ReviewRepositoryCustom {
     List<ReviewDetailResponse> findByUserIdAndBetweenTimeRange(Long userId, ReviewStatsRequest request);
+
+    Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(Pageable pageable, Long userId, Integer feelingsScore, LocalDate startDate, LocalDate endDate);
 }

--- a/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
@@ -58,7 +58,6 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                 .select(Projections.fields(ReviewDetailWithTaskDateResponse.class,
                         review.id.as("reviewId"),
                         review.subject,
-                        review.contents,
                         review.feelingsScore,
                         tasks.taskDate
                 ))

--- a/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
@@ -1,11 +1,16 @@
 package com.growth.task.review.repository.impl;
 
 import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
 import com.growth.task.review.dto.ReviewStatsRequest;
 import com.growth.task.review.repository.ReviewRepositoryCustom;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -31,26 +36,77 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                         review.feelingsScore
                 ))
                 .from(review)
-                .leftJoin(tasks)
+                .innerJoin(tasks)
                 .on(review.tasks.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        betweenTimeRange(request)
+                        betweenTimeRange(request.getStartDate(), request.getEndDate())
                 )
                 .fetch()
                 ;
     }
 
-    private static BooleanExpression eqUserId(Long userId) {
+    @Override
+    public Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(
+            Pageable pageable,
+            Long userId,
+            Integer feelingsScore,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        List<ReviewDetailWithTaskDateResponse> content = queryFactory
+                .select(Projections.fields(ReviewDetailWithTaskDateResponse.class,
+                        review.id.as("reviewId"),
+                        review.subject,
+                        review.contents,
+                        review.feelingsScore,
+                        tasks.taskDate
+                ))
+                .from(review)
+                .innerJoin(tasks)
+                .on(review.tasks.eq(tasks))
+                .where(
+                        eqUserId(userId),
+                        eqFeelingsScore(feelingsScore),
+                        betweenTimeRange(startDate, endDate)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(tasks.taskDate.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(review.count())
+                .from(review)
+                .innerJoin(tasks)
+                .on(review.tasks.eq(tasks))
+                .where(
+                        eqUserId(userId),
+                        eqFeelingsScore(feelingsScore),
+                        betweenTimeRange(startDate, endDate)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression eqUserId(Long userId) {
         return tasks.user.userId.eq(userId);
     }
 
-    private static BooleanExpression betweenTimeRange(ReviewStatsRequest request) {
-        LocalDate startDate = request.getStartDate();
-        LocalDate endDate = request.getEndDate();
+    private BooleanExpression betweenTimeRange(LocalDate startDate, LocalDate endDate) {
         if (startDate == null && endDate == null) {
             return null;
         }
         return tasks.taskDate.between(startDate, endDate);
+    }
+
+    private BooleanExpression eqFeelingsScore(Integer feelingsScore) {
+        System.out.println("repository feelingsScore: " + feelingsScore);
+        if (feelingsScore == null) {
+            return null;
+        }
+        return review.feelingsScore.eq(feelingsScore);
     }
 }

--- a/app-server/src/main/java/com/growth/task/review/service/ReviewListService.java
+++ b/app-server/src/main/java/com/growth/task/review/service/ReviewListService.java
@@ -1,9 +1,13 @@
 package com.growth.task.review.service;
 
 import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
+import com.growth.task.review.dto.ReviewListRequest;
 import com.growth.task.review.dto.ReviewStatsRequest;
 import com.growth.task.review.dto.ReviewStatsResponse;
 import com.growth.task.review.repository.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +29,13 @@ public class ReviewListService {
         this.reviewRepository = reviewRepository;
     }
 
+    /**
+     * 사용자가 기록한 감정 기록 통계를 조회한다.
+     *
+     * @param userId  사용자 id
+     * @param request 날짜 범위
+     * @return 감정 기록 통계
+     */
     @Transactional(readOnly = true)
     public ReviewStatsResponse getReviewStats(Long userId, ReviewStatsRequest request) {
         List<ReviewDetailResponse> reviews = getReviewList(userId, request);
@@ -34,9 +45,29 @@ public class ReviewListService {
         return new ReviewStatsResponse(feelings);
     }
 
+    /**
+     * 사용자가 기록한 회고 리스트를 조회한다
+     *
+     * @param userId  사용자 id
+     * @param request 날짜 범위
+     * @return 감정 기록 리스트
+     */
     @Transactional(readOnly = true)
     public List<ReviewDetailResponse> getReviewList(Long userId, ReviewStatsRequest request) {
         return reviewRepository.findByUserIdAndBetweenTimeRange(userId, request);
+    }
+
+    /**
+     * 사용자가 기록한 감정점수에 따른 회고 리스트를 조회한다
+     *
+     * @param pageable 페이징
+     * @param userId   사용자 리스트
+     * @param request  감정 점수, 날짜
+     * @return 감정 기록 리스트
+     */
+    @Transactional(readOnly = true)
+    public Page<ReviewDetailWithTaskDateResponse> getReviewByUserIdAndParams(Pageable pageable, Long userId, ReviewListRequest request) {
+        return reviewRepository.findByUserAndParams(pageable, userId, request.getFeelingsScore(), request.getStartDate(), request.getEndDate());
     }
 
     private Map<Integer, Long> countFeelingsScore(List<ReviewDetailResponse> reviews) {

--- a/app-server/src/main/java/com/growth/task/todo/dto/TodoListRequest.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/TodoListRequest.java
@@ -3,14 +3,13 @@ package com.growth.task.todo.dto;
 import com.growth.task.todo.enums.Status;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class TodoListRequest {
     private Status status;
+
     @Builder
-    public TodoListRequest(String status) {
-        this.status = Status.valueOf(status);
+    public TodoListRequest(Status status) {
+        this.status = status;
     }
 }

--- a/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
+++ b/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
@@ -3,6 +3,7 @@ package com.growth.task.review.repository;
 import com.growth.task.config.TestQueryDslConfig;
 import com.growth.task.review.domain.Review;
 import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
 import com.growth.task.review.dto.ReviewStatsRequest;
 import com.growth.task.task.domain.Tasks;
 import com.growth.task.task.repository.TasksRepository;
@@ -13,10 +14,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,11 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(TestQueryDslConfig.class)
 @DataJpaTest
 class ReviewRepositoryTest {
-    public static final LocalDate DATE_2023_11_01 = LocalDate.of(2023, 11, 1);
-    public static final LocalDate DATE_2023_11_02 = LocalDate.of(2023, 11, 2);
-    public static final LocalDate DATE_2023_11_03 = LocalDate.of(2023, 11, 3);
-    public static final LocalDate DATE_2023_11_04 = LocalDate.of(2023, 11, 4);
-    public static final LocalDate DATE_2023_11_05 = LocalDate.of(2023, 11, 5);
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 10, Sort.by("id").descending());
+    private static final LocalDate DATE_2023_11_01 = LocalDate.of(2023, 11, 1);
+    private static final LocalDate DATE_2023_11_02 = LocalDate.of(2023, 11, 2);
+    private static final LocalDate DATE_2023_11_03 = LocalDate.of(2023, 11, 3);
+    private static final LocalDate DATE_2023_11_04 = LocalDate.of(2023, 11, 4);
+    private static final LocalDate DATE_2023_11_05 = LocalDate.of(2023, 11, 5);
     @Autowired
     private UsersRepository usersRepository;
     @Autowired
@@ -149,6 +157,46 @@ class ReviewRepositoryTest {
                 List<ReviewDetailResponse> actual = reviewRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), request);
 
                 assertThat(actual).hasSize(3);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserAndParams")
+    class Describe_findByUserAndParams {
+        private Users user;
+
+        @BeforeEach
+        void prepare() {
+            user = getUser("test", "1234");
+            Tasks task1 = getTask(user, DATE_2023_11_01);
+            Tasks task2 = getTask(user, DATE_2023_11_02);
+            Tasks task3 = getTask(user, DATE_2023_11_03);
+            Tasks task4 = getTask(user, DATE_2023_11_04);
+            Tasks task5 = getTask(user, DATE_2023_11_05);
+
+            getReview(task1, "subject 1", "review 1", 9);
+            getReview(task2, "subject 2", "review 2", 9);
+            getReview(task3, "subject 3", "review 3", 5);
+            getReview(task4, "subject 4", "review 4", 5);
+            getReview(task5, "subject 5", "review 5", 1);
+        }
+
+        @Nested
+        @DisplayName("사용자 아이디와 기분점수, 날짜가 주어지면")
+        class Context_with_user_id_feelings_score_task_date {
+
+            @ParameterizedTest(name = "feelings Score = {0}, result size = {1}")
+            @CsvSource({
+                    "1,1",
+                    "5,2",
+                    "9,2"
+            })
+            @DisplayName("기분 점수에 따른 리뷰 리스트를 불러온다")
+            void it_return_review_list_by_user(int feelingsScore, int size) {
+                Page<ReviewDetailWithTaskDateResponse> actual = reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, user.getUserId(), feelingsScore, DATE_2023_11_01, DATE_2023_11_05);
+
+                assertThat(actual).hasSize(size);
             }
         }
     }

--- a/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
@@ -1,6 +1,8 @@
 package com.growth.task.review.service;
 
 import com.growth.task.review.dto.ReviewDetailResponse;
+import com.growth.task.review.dto.ReviewDetailWithTaskDateResponse;
+import com.growth.task.review.dto.ReviewListRequest;
 import com.growth.task.review.dto.ReviewStatsRequest;
 import com.growth.task.review.dto.ReviewStatsResponse;
 import com.growth.task.review.repository.ReviewRepository;
@@ -11,6 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,6 +28,7 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewListServiceTest {
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 10, Sort.by("id").descending());
     public static final long USER_ID = 1L;
     public static final LocalDate LOCAL_DATE_11_20 = LocalDate.of(2023, 11, 20);
     public static final LocalDate LOCAL_DATE_11_19 = LocalDate.of(2023, 11, 19);
@@ -76,6 +84,46 @@ class ReviewListServiceTest {
                         10, 1L
                 );
                 assertThat(reviewStats.getFeelings()).isEqualTo(expected);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getReviewByUserIdAndParams")
+    class Describe_getReviewByUserIdAndParams {
+        @Nested
+        @DisplayName("사용자 아이다와 날짜가 주어지면")
+        class Context_with_user_id_and_time_range {
+            private ReviewListRequest request = new ReviewListRequest(3, LOCAL_DATE_11_19, LOCAL_DATE_11_20);
+
+            @BeforeEach
+            void prepare() {
+                List<ReviewDetailResponse> reviews = List.of(
+                        new ReviewDetailResponse(1L, "subject1", "review1", 1),
+                        new ReviewDetailResponse(2L, "subject2", "review2", 1),
+                        new ReviewDetailResponse(3L, "subject3", "review3", 3),
+                        new ReviewDetailResponse(4L, "subject4", "review4", 3),
+                        new ReviewDetailResponse(5L, "subject5", "review5", 3),
+                        new ReviewDetailResponse(6L, "subject6", "review6", 6),
+                        new ReviewDetailResponse(7L, "subject7", "review7", 7),
+                        new ReviewDetailResponse(8L, "subject8", "review8", 7),
+                        new ReviewDetailResponse(9L, "subject9", "review9", 9),
+                        new ReviewDetailResponse(10L, "subject10", "review10", 10)
+                );
+                Page page = new PageImpl(reviews.stream()
+                        .filter(review -> review.getFeelingsScore() == 3)
+                        .toList());
+
+                given(reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, USER_ID, request.getFeelingsScore(), request.getStartDate(), request.getEndDate()))
+                        .willReturn(page);
+            }
+
+            @Test
+            @DisplayName("회고 리스트를 리턴한다")
+            void it_return_review_list() {
+                Page<ReviewDetailWithTaskDateResponse> reviews = reviewListService.getReviewByUserIdAndParams(DEFAULT_PAGEABLE, USER_ID, request);
+
+                assertThat(reviews).hasSize(3);
             }
         }
     }

--- a/app-server/src/test/java/com/growth/task/todo/application/TodoListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/application/TodoListServiceTest.java
@@ -239,7 +239,7 @@ public class TodoListServiceTest {
         @Nested
         @DisplayName("사용자 아이디와 status가 주어지면")
         class Context_with_userId {
-            private TodoListRequest request = new TodoListRequest(Status.READY.name());
+            private TodoListRequest request = new TodoListRequest(Status.READY);
 
             @BeforeEach
             void prepare() {


### PR DESCRIPTION
issue no. #216 

`/api/v1/mypage/{user_id}/review` 

request param 
 - `feelings_score` : 감정 점수
 - `start_date` : 시작 날짜
 - `end_date` : 마지막 날짜 
 
response 
 - `review_id` : 회고 아이디
 - `subject` : 회고 제목
 - `feelings_score` : 기분 점수
 - `task_date` : 회고 날짜 
 - 페이징 정보