### PR TITLE
[Backend] 투두 통계 세부 리스트 파라미터 조건에 날짜를 추가하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/todo/application/TodoListService.java
+++ b/app-server/src/main/java/com/growth/task/todo/application/TodoListService.java
@@ -48,12 +48,25 @@ public class TodoListService {
     }
 
     /**
+     * userId와 parameter에 해당하는 투두 상세 내역 리스트가 페이징되어 리턴한다
+     *
+     * @param pageable 페이징
+     * @param userId   사용자 아이디
+     * @param request  파라미터
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public Page<TodoDetailResponse> getTodoByUserAndParams(Pageable pageable, Long userId, TodoListRequest request) {
+        return todosRepository.findAllByUserAndParams(pageable, userId, request.getStatus(), request.getStartDate(), request.getEndDate());
+    }
+
+    /**
      * 날짜 범위에 해당하는 todo를 조회하여 통계 값을 리턴한다.
      * 총 투두 개수, 완료한 투두 개수, 진행 중인 투두 개수, 미완료인 투두 개수
      */
     @Transactional(readOnly = true)
     public TodoStatsResponse getTodoStats(Long userId, TodoStatsRequest request) {
-        List<TodoResponse> todos = todosRepository.findByUserIdAndBetweenTimeRange(userId, request);
+        List<TodoResponse> todos = todosRepository.findByUserIdAndBetweenTimeRange(userId, request.getStartDate(), request.getEndDate());
 
         return aggregate(todos);
     }
@@ -78,17 +91,5 @@ public class TodoListService {
         return todos.stream()
                 .filter(todo -> todo.getStatus() == status)
                 .count();
-    }
-
-    /**
-     * userId와 parameter에 해당하는 투두 상세 내역 리스트가 페이징되어 리턴한다
-     * @param pageable 페이징
-     * @param userId 사용자 아이디
-     * @param request 파라미터
-     * @return
-     */
-    @Transactional(readOnly = true)
-    public Page<TodoDetailResponse> getTodoByUserAndParams(Pageable pageable, Long userId, TodoListRequest request) {
-        return todosRepository.findAllByUserAndParams(pageable, userId, request);
     }
 }

--- a/app-server/src/main/java/com/growth/task/todo/dto/TodoListRequest.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/TodoListRequest.java
@@ -1,15 +1,31 @@
 package com.growth.task.todo.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.growth.task.todo.enums.Status;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 public class TodoListRequest {
     private Status status;
+    @DateTimeFormat(pattern = "YYYY-MM-dd")
+    private LocalDate startDate;
+    @DateTimeFormat(pattern = "YYYY-MM-dd")
+    private LocalDate endDate;
 
     @Builder
-    public TodoListRequest(Status status) {
+    public TodoListRequest(
+            Status status,
+            LocalDate start_date,
+            LocalDate end_date
+    ) {
         this.status = status;
+        this.endDate = end_date;
+        this.startDate = start_date;
     }
 }

--- a/app-server/src/main/java/com/growth/task/todo/repository/TodosRepositoryCustom.java
+++ b/app-server/src/main/java/com/growth/task/todo/repository/TodosRepositoryCustom.java
@@ -1,22 +1,22 @@
 package com.growth.task.todo.repository;
 
 import com.growth.task.task.dto.TaskTodoDetailResponse;
-import com.growth.task.todo.dto.TodoListRequest;
 import com.growth.task.todo.dto.TodoResponse;
-import com.growth.task.todo.dto.TodoStatsRequest;
 import com.growth.task.todo.dto.response.TodoDetailResponse;
 import com.growth.task.todo.dto.response.TodoWithPomodoroResponse;
+import com.growth.task.todo.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TodosRepositoryCustom {
     List<TaskTodoDetailResponse> getTaskTodoPreview(Long taskId, int limit);
 
-    List<TodoResponse> findByUserIdAndBetweenTimeRange(Long userId, TodoStatsRequest request);
+    List<TodoResponse> findByUserIdAndBetweenTimeRange(Long userId, LocalDate startDate, LocalDate endDate);
 
     List<TodoWithPomodoroResponse> findTodoWithPomodoroByTaskId(Long taskId);
 
-    Page<TodoDetailResponse> findAllByUserAndParams(Pageable pageable, Long userId, TodoListRequest request);
+    Page<TodoDetailResponse> findAllByUserAndParams(Pageable pageable, Long userId, Status status, LocalDate startDate, LocalDate endDate);
 }

--- a/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
@@ -1,9 +1,7 @@
 package com.growth.task.todo.repository.impl;
 
 import com.growth.task.task.dto.TaskTodoDetailResponse;
-import com.growth.task.todo.dto.TodoListRequest;
 import com.growth.task.todo.dto.TodoResponse;
-import com.growth.task.todo.dto.TodoStatsRequest;
 import com.growth.task.todo.dto.response.TodoDetailResponse;
 import com.growth.task.todo.dto.response.TodoWithPomodoroResponse;
 import com.growth.task.todo.enums.Status;
@@ -54,7 +52,7 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
     }
 
     @Override
-    public List<TodoResponse> findByUserIdAndBetweenTimeRange(Long userId, TodoStatsRequest request) {
+    public List<TodoResponse> findByUserIdAndBetweenTimeRange(Long userId, LocalDate startDate, LocalDate endDate) {
         return queryFactory.select(Projections.fields(TodoResponse.class,
                         todos.todoId,
                         todos.task.taskId,
@@ -66,7 +64,7 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
                 .on(todos.task.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        betweenTimeRange(request)
+                        betweenTimeRange(startDate, endDate)
                 )
                 .fetch()
                 ;
@@ -90,7 +88,7 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
     }
 
     @Override
-    public Page<TodoDetailResponse> findAllByUserAndParams(Pageable pageable, Long userId, TodoListRequest request) {
+    public Page<TodoDetailResponse> findAllByUserAndParams(Pageable pageable, Long userId, Status status, LocalDate startDate, LocalDate endDate) {
 
         List<TodoDetailResponse> content = queryFactory
                 .select(Projections.fields(TodoDetailResponse.class,
@@ -107,7 +105,8 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
                 .on(pomodoros.todo.eq(todos))
                 .where(
                         eqUserId(userId),
-                        eqStatus(request.getStatus())
+                        eqStatus(status),
+                        betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -123,7 +122,8 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
                 .on(pomodoros.todo.eq(todos))
                 .where(
                         eqUserId(userId),
-                        eqStatus(request.getStatus())
+                        eqStatus(status),
+                        betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
@@ -143,9 +143,7 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
 
     }
 
-    private static BooleanExpression betweenTimeRange(TodoStatsRequest request) {
-        LocalDate startDate = request.getStartDate();
-        LocalDate endDate = request.getEndDate();
+    private static BooleanExpression betweenTimeRange(LocalDate startDate, LocalDate endDate) {
         if (startDate == null && endDate == null) {
             return null;
         }

--- a/app-server/src/test/java/com/growth/task/mypage/controller/MyPageControllerTest.java
+++ b/app-server/src/test/java/com/growth/task/mypage/controller/MyPageControllerTest.java
@@ -229,6 +229,8 @@ class MyPageControllerTest {
             if (request.getStatus() != null) {
                 params.add("status", request.getStatus().name());
             }
+            params.add("start_date", String.valueOf(request.getStartDate()));
+            params.add("end_date", String.valueOf(request.getEndDate()));
 
             return mockMvc.perform(get(MYPAGE_TODO_LIST_URL, userId)
                     .params(params)
@@ -285,7 +287,7 @@ class MyPageControllerTest {
             })
             @DisplayName("투두 리스트를 리턴한다")
             void it_return_todo_list(Status status, int resultSize) throws Exception {
-                request = new TodoListRequest(status);
+                request = new TodoListRequest(status, LOCAL_DATE_11_19, LOCAL_DATE_11_23);
 
                 final ResultActions resultActions = subject(user.getUserId(), request);
 

--- a/app-server/src/test/java/com/growth/task/todo/application/TodoListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/application/TodoListServiceTest.java
@@ -42,6 +42,7 @@ public class TodoListServiceTest {
     private static final long USER_ID = 1L;
     private static final LocalDate LOCAL_DATE_11_20 = LocalDate.of(2023, 11, 20);
     private static final LocalDate LOCAL_DATE_11_19 = LocalDate.of(2023, 11, 19);
+    public static final LocalDate LOCAL_DATE_12_01 = LocalDate.of(2023, 12, 01);
     private static final int TOTAL_COUNT = 10;
     private static final int STATS_DONE = 7;
     private static final int STATS_PROGRESS = 2;
@@ -213,7 +214,7 @@ public class TodoListServiceTest {
                         new TodoResponse(1L, 4L, "쓰레기버리기", Status.DONE),
                         new TodoResponse(1L, 4L, "계획짜기", Status.PROGRESS)
                 );
-                given(todosRepository.findByUserIdAndBetweenTimeRange(USER_ID, request))
+                given(todosRepository.findByUserIdAndBetweenTimeRange(USER_ID, LOCAL_DATE_11_19, LOCAL_DATE_11_20))
                         .willReturn(todos);
             }
 
@@ -239,17 +240,17 @@ public class TodoListServiceTest {
         @Nested
         @DisplayName("사용자 아이디와 status가 주어지면")
         class Context_with_userId {
-            private TodoListRequest request = new TodoListRequest(Status.READY);
+            private TodoListRequest request = new TodoListRequest(Status.READY, LOCAL_DATE_11_20, LOCAL_DATE_12_01);
 
             @BeforeEach
             void prepare() {
                 Page page = new PageImpl(List.of(
-                        new TodoDetailResponse("책읽기", Status.READY, 0, 3, LocalDate.of(2023, 12, 01)),
-                        new TodoDetailResponse("소설읽기", Status.READY, 0, 3, LocalDate.of(2023, 12, 01)),
-                        new TodoDetailResponse("책읽기", Status.READY, 0, 3, LocalDate.of(2023, 12, 01)),
-                        new TodoDetailResponse("운동하기", Status.READY, 0, 3, LocalDate.of(2023, 12, 01))
+                        new TodoDetailResponse("책읽기", Status.READY, 0, 3, LOCAL_DATE_11_20),
+                        new TodoDetailResponse("소설읽기", Status.READY, 0, 3, LOCAL_DATE_12_01),
+                        new TodoDetailResponse("책읽기", Status.READY, 0, 3, LOCAL_DATE_12_01),
+                        new TodoDetailResponse("운동하기", Status.READY, 0, 3, LOCAL_DATE_12_01)
                 ));
-                given(todosRepository.findAllByUserAndParams(DEFAULT_PAGEABLE, USER_ID, request))
+                given(todosRepository.findAllByUserAndParams(DEFAULT_PAGEABLE, USER_ID, Status.READY, LOCAL_DATE_11_20, LOCAL_DATE_12_01))
                         .willReturn(page);
             }
 

--- a/app-server/src/test/java/com/growth/task/todo/repository/TodosRepositoryTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/repository/TodosRepositoryTest.java
@@ -196,14 +196,12 @@ class TodosRepositoryTest {
         }
 
         @Nested
-        @DisplayName("사용자 아이디와 빈 날짜가 주어지면")
+        @DisplayName("사용자 아이디와 날짜가 주어지면")
         class Context_with_user_id {
-            private final TodoStatsRequest request = new TodoStatsRequest(null, null);
-
             @Test
             @DisplayName("사용자 아이디에 해당하는 todo 리스트를 불러온다")
             void it_return_todo_list_by_user() {
-                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), request);
+                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), null, null);
 
                 assertThat(actual).hasSize(10);
             }
@@ -212,12 +210,10 @@ class TodosRepositoryTest {
         @Nested
         @DisplayName("사용자 아이디와 끝 날짜가 주어지면")
         class Context_with_user_id_and_end_date {
-            private final TodoStatsRequest request = new TodoStatsRequest(null, DATE_2023_11_03);
-
             @Test
             @DisplayName("사용자 아이디와 날짜 범위에 해당하는 todo 리스트를 불러온다")
             void it_return_todo_list_by_user() {
-                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), request);
+                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), null, DATE_2023_11_03);
 
                 assertThat(actual).hasSize(6);
             }
@@ -226,12 +222,10 @@ class TodosRepositoryTest {
         @Nested
         @DisplayName("사용자 아이디와 시작 날짜가 주어지면")
         class Context_with_user_id_and_start_date {
-            private final TodoStatsRequest request = new TodoStatsRequest(DATE_2023_11_03, null);
-
             @Test
             @DisplayName("사용자 아이디와 날짜 범위에 해당하는 todo 리스트를 불러온다")
             void it_return_todo_list_by_user() {
-                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), request);
+                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), DATE_2023_11_03, null);
 
                 assertThat(actual).hasSize(7);
             }
@@ -240,12 +234,10 @@ class TodosRepositoryTest {
         @Nested
         @DisplayName("사용자 아이디와 날짜가 주어지면")
         class Context_with_user_id_and_date {
-            private final TodoStatsRequest request = new TodoStatsRequest(DATE_2023_11_03, DATE_2023_11_04);
-
             @Test
             @DisplayName("사용자 아이디와 날짜 범위에 해당하는 todo 리스트를 불러온다")
             void it_return_todo_list_by_user() {
-                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), request);
+                List<TodoResponse> actual = todosRepository.findByUserIdAndBetweenTimeRange(user.getUserId(), DATE_2023_11_03, DATE_2023_11_04);
 
                 assertThat(actual).hasSize(6);
             }


### PR DESCRIPTION
issue no. #240

투두 통계 세부 리스트 조회시 날짜 조건을 받아, 날짜 범위 내의 리스트만 가져오도록 한다