### PR TITLE
[Backend] 감정 통계 세부 리스트 조회시 감정 점수를 리스트로 받아 조회하라

### DIFF
--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
@@ -2,22 +2,18 @@ package com.growth.task.review.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 public class ReviewListRequest {
     private static final String FEELINGS_SCORE_VALID_MESSAGE = "기분 점수는 1 ~ 10 사이를 입력해주세요.";
-
-    @Min(value = 1, message = FEELINGS_SCORE_VALID_MESSAGE)
-    @Max(value = 10, message = FEELINGS_SCORE_VALID_MESSAGE)
-    private Integer feelingsScore;
+    private List<Integer> feelingsScore;
     @DateTimeFormat(pattern = "YYYY-MM-dd")
     private LocalDate startDate;
     @DateTimeFormat(pattern = "YYYY-MM-dd")
@@ -25,7 +21,7 @@ public class ReviewListRequest {
 
     @Builder
     public ReviewListRequest(
-            Integer feelings_score,
+            List<Integer> feelings_score,
             LocalDate start_date,
             LocalDate end_date
     ) {

--- a/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ReviewRepositoryCustom {
     List<ReviewDetailResponse> findByUserIdAndBetweenTimeRange(Long userId, ReviewStatsRequest request);
 
-    Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(Pageable pageable, Long userId, Integer feelingsScore, LocalDate startDate, LocalDate endDate);
+    Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(Pageable pageable, Long userId, List<Integer> feelingsScore, LocalDate startDate, LocalDate endDate);
 }

--- a/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
@@ -50,7 +50,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
     public Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(
             Pageable pageable,
             Long userId,
-            Integer feelingsScore,
+            List<Integer> feelingsScore,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -66,7 +66,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                 .on(review.tasks.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        eqFeelingsScore(feelingsScore),
+                        inFeelingsScore(feelingsScore),
                         betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
@@ -81,7 +81,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                 .on(review.tasks.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        eqFeelingsScore(feelingsScore),
+                        inFeelingsScore(feelingsScore),
                         betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
@@ -101,11 +101,10 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
         return tasks.taskDate.between(startDate, endDate);
     }
 
-    private BooleanExpression eqFeelingsScore(Integer feelingsScore) {
-        System.out.println("repository feelingsScore: " + feelingsScore);
-        if (feelingsScore == null) {
+    private BooleanExpression inFeelingsScore(List<Integer> feelingsScores) {
+        if (feelingsScores == null || feelingsScores.isEmpty()) {
             return null;
         }
-        return review.feelingsScore.eq(feelingsScore);
+        return review.feelingsScore.in(feelingsScores);
     }
 }

--- a/app-server/src/main/resources/schema.sql
+++ b/app-server/src/main/resources/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pomodoros (
 CREATE TABLE review (
     review_id bigint NOT NULL AUTO_INCREMENT,
     task_id bigint NOT NULL,
+    subject varchar(50) NOT NULL,
     contents TEXT NOT NULL,
     feelings_score int NOT NULL,
     created_at timestamp NOT NULL,

--- a/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
+++ b/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
@@ -194,7 +194,7 @@ class ReviewRepositoryTest {
             })
             @DisplayName("기분 점수에 따른 리뷰 리스트를 불러온다")
             void it_return_review_list_by_user(int feelingsScore, int size) {
-                Page<ReviewDetailWithTaskDateResponse> actual = reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, user.getUserId(), feelingsScore, DATE_2023_11_01, DATE_2023_11_05);
+                Page<ReviewDetailWithTaskDateResponse> actual = reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, user.getUserId(), List.of(feelingsScore), DATE_2023_11_01, DATE_2023_11_05);
 
                 assertThat(actual).hasSize(size);
             }

--- a/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
@@ -94,7 +94,7 @@ class ReviewListServiceTest {
         @Nested
         @DisplayName("사용자 아이다와 날짜가 주어지면")
         class Context_with_user_id_and_time_range {
-            private ReviewListRequest request = new ReviewListRequest(3, LOCAL_DATE_11_19, LOCAL_DATE_11_20);
+            private ReviewListRequest request = new ReviewListRequest(List.of(3), LOCAL_DATE_11_19, LOCAL_DATE_11_20);
 
             @BeforeEach
             void prepare() {


### PR DESCRIPTION
issue no. #247

감정은 범위로 조회해야하기 때문에, 조건 조회를 in 절로 변경 
파라미터도 여러개를 받을 수 있도록 리스트로 타입 변경 