### PR TITLE
[Backend] todo 리스트 가져올 때, task id로 필터링이 되지 않는 이슈 #257

### DIFF
--- a/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
+++ b/app-server/src/main/java/com/growth/task/review/dto/ReviewListRequest.java
@@ -2,22 +2,18 @@ package com.growth.task.review.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 public class ReviewListRequest {
     private static final String FEELINGS_SCORE_VALID_MESSAGE = "기분 점수는 1 ~ 10 사이를 입력해주세요.";
-
-    @Min(value = 1, message = FEELINGS_SCORE_VALID_MESSAGE)
-    @Max(value = 10, message = FEELINGS_SCORE_VALID_MESSAGE)
-    private Integer feelingsScore;
+    private List<Integer> feelingsScore;
     @DateTimeFormat(pattern = "YYYY-MM-dd")
     private LocalDate startDate;
     @DateTimeFormat(pattern = "YYYY-MM-dd")
@@ -25,7 +21,7 @@ public class ReviewListRequest {
 
     @Builder
     public ReviewListRequest(
-            Integer feelings_score,
+            List<Integer> feelings_score,
             LocalDate start_date,
             LocalDate end_date
     ) {

--- a/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/ReviewRepositoryCustom.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ReviewRepositoryCustom {
     List<ReviewDetailResponse> findByUserIdAndBetweenTimeRange(Long userId, ReviewStatsRequest request);
 
-    Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(Pageable pageable, Long userId, Integer feelingsScore, LocalDate startDate, LocalDate endDate);
+    Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(Pageable pageable, Long userId, List<Integer> feelingsScore, LocalDate startDate, LocalDate endDate);
 }

--- a/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/review/repository/impl/ReviewRepositoryCustomImpl.java
@@ -50,7 +50,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
     public Page<ReviewDetailWithTaskDateResponse> findByUserAndParams(
             Pageable pageable,
             Long userId,
-            Integer feelingsScore,
+            List<Integer> feelingsScore,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -66,7 +66,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                 .on(review.tasks.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        eqFeelingsScore(feelingsScore),
+                        inFeelingsScore(feelingsScore),
                         betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
@@ -81,7 +81,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                 .on(review.tasks.eq(tasks))
                 .where(
                         eqUserId(userId),
-                        eqFeelingsScore(feelingsScore),
+                        inFeelingsScore(feelingsScore),
                         betweenTimeRange(startDate, endDate)
                 )
                 .offset(pageable.getOffset())
@@ -101,11 +101,10 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
         return tasks.taskDate.between(startDate, endDate);
     }
 
-    private BooleanExpression eqFeelingsScore(Integer feelingsScore) {
-        System.out.println("repository feelingsScore: " + feelingsScore);
-        if (feelingsScore == null) {
+    private BooleanExpression inFeelingsScore(List<Integer> feelingsScores) {
+        if (feelingsScores == null || feelingsScores.isEmpty()) {
             return null;
         }
-        return review.feelingsScore.eq(feelingsScore);
+        return review.feelingsScore.in(feelingsScores);
     }
 }

--- a/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
+++ b/app-server/src/main/java/com/growth/task/todo/repository/impl/TodosRepositoryCustomImpl.java
@@ -83,6 +83,7 @@ public class TodosRepositoryCustomImpl implements TodosRepositoryCustom {
                 .from(todos)
                 .leftJoin(pomodoros)
                 .on(pomodoros.todo.eq(todos))
+                .where(eqTaskId(taskId))
                 .fetch()
                 ;
     }

--- a/app-server/src/main/resources/schema.sql
+++ b/app-server/src/main/resources/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pomodoros (
 CREATE TABLE review (
     review_id bigint NOT NULL AUTO_INCREMENT,
     task_id bigint NOT NULL,
+    subject varchar(50) NOT NULL,
     contents TEXT NOT NULL,
     feelings_score int NOT NULL,
     created_at timestamp NOT NULL,

--- a/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
+++ b/app-server/src/test/java/com/growth/task/review/repository/ReviewRepositoryTest.java
@@ -194,7 +194,7 @@ class ReviewRepositoryTest {
             })
             @DisplayName("기분 점수에 따른 리뷰 리스트를 불러온다")
             void it_return_review_list_by_user(int feelingsScore, int size) {
-                Page<ReviewDetailWithTaskDateResponse> actual = reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, user.getUserId(), feelingsScore, DATE_2023_11_01, DATE_2023_11_05);
+                Page<ReviewDetailWithTaskDateResponse> actual = reviewRepository.findByUserAndParams(DEFAULT_PAGEABLE, user.getUserId(), List.of(feelingsScore), DATE_2023_11_01, DATE_2023_11_05);
 
                 assertThat(actual).hasSize(size);
             }

--- a/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/review/service/ReviewListServiceTest.java
@@ -94,7 +94,7 @@ class ReviewListServiceTest {
         @Nested
         @DisplayName("사용자 아이다와 날짜가 주어지면")
         class Context_with_user_id_and_time_range {
-            private ReviewListRequest request = new ReviewListRequest(3, LOCAL_DATE_11_19, LOCAL_DATE_11_20);
+            private ReviewListRequest request = new ReviewListRequest(List.of(3), LOCAL_DATE_11_19, LOCAL_DATE_11_20);
 
             @BeforeEach
             void prepare() {

--- a/app-server/src/test/java/com/growth/task/todo/controller/TodoListControllerTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/controller/TodoListControllerTest.java
@@ -139,10 +139,13 @@ class TodoListControllerTest {
             @BeforeEach
             void setTask() {
                 task = createTask(user, LOCAL_DATE_11_21);
+                Tasks otherTask = createTask(user, LOCAL_DATE_11_22);
 
                 createTodo(task, "책 읽기", PROGRESS, PERFORM_COUNT, PLAN_COUNT);
                 createTodo(task, "테스트 코드 짜기", PROGRESS, PERFORM_COUNT, PLAN_COUNT);
                 createTodo(task, "스터디 참여", Status.DONE, PERFORM_COUNT, PLAN_COUNT);
+
+                createTodo(otherTask, "운동 하기", PROGRESS, PERFORM_COUNT, PLAN_COUNT);
             }
 
             @Test


### PR DESCRIPTION
issue no. #257

todo 리스트 가져올 때, task_id가 필터링이 안되고 전체 리스트를 불러오고 있었음
패키지 리팩토링을 하면서 기존의 JPA로 여러번 DB 조회 후 각 데이터를 매팽하는 방식에서 
queryDsl로 한방에 가져오는 방식으로 변환하는 과정에서 해당 조건 누락. 