### PR TITLE
[Frontend] 할 일 25분 지난 후 휴식으로 화면 전환으로 변경하라

### DIFF
--- a/app-client/src/components/Pomodoro/Pomodoro.tsx
+++ b/app-client/src/components/Pomodoro/Pomodoro.tsx
@@ -70,7 +70,7 @@ function Pomodoro({ startTime, userTime, timerState }: PomodoroProps) {
 
   return (
     <>
-      {(timerState === 'INITIAL' || timerState === 'FINISHED') && (
+      {timerState === 'INITIAL' && (
         <CenteredBox>
           <DefaultPomodoro />
         </CenteredBox>

--- a/app-client/src/components/Pomodoro/Timer.tsx
+++ b/app-client/src/components/Pomodoro/Timer.tsx
@@ -27,7 +27,6 @@ const Timer = ({ time, timerState, isBreak }: TimerProps) => {
           {minute} : {second}
         </Time>
       )}
-      {timerState === 'FINISHED' && <Time> 종료 </Time>}
     </>
   );
 };

--- a/app-client/src/pages/TodosPage/index.tsx
+++ b/app-client/src/pages/TodosPage/index.tsx
@@ -91,6 +91,12 @@ const Todos = () => {
       resetTimer(timer, todos, 'reset', todoList);
       closeReview();
     });
+
+    if (timerState === 'FINISHED') {
+      timer.showBreak();
+      resetTimer(timer, todos, '휴식');
+      todos.setTodoId(0);
+    }
   }, [selectedTaskId, isTodoChange]);
 
   useEffect(() => {
@@ -107,6 +113,7 @@ const Todos = () => {
 
         if (elapsedTime >= USER_TIME) {
           complete();
+
           updatePerformPomodoro(todoId).then(() =>
             setIsTodoChange(!isTodoChange),
           );


### PR DESCRIPTION
<img width="253" alt="image" src="https://github.com/growth-ring/taskgrow/assets/116357790/aa813f8b-5bff-425c-9c21-e56e736cfdd8">

기존: 할 일이 끝난 후 끝났다는 화면 표시
변경 후: 할 일이 끝난 후 휴식 화면으로 전환