### PR TITLE
[Frontend] 선택한 할 일 박스 바깥에 border로 표시하라

### DIFF
--- a/app-client/src/components/Todos/Todo.tsx
+++ b/app-client/src/components/Todos/Todo.tsx
@@ -86,7 +86,14 @@ const Todo = ({
             ? 'color-main-colorbg-gradient-to-r from-transparent to-transparent hover:from-slate-100'
             : 'bg-gradient-to-r from-indigo-100 to-transparent hover:from-indigo-200'
         } transition ease-linear duration-150 cursor-pointer`}
-        style={{ display: 'flex', width: '100%' }}
+        style={{
+          display: 'flex',
+          width: '100%',
+          border: todos.todoId === id ? '2.5px solid var(--main-color)' : '',
+          borderRadius: '0.5rem',
+          padding:
+            todos.todoId === id ? '0.8rem 0 0.8rem 0.8rem' : '1rem 0 1rem 1rem',
+        }}
       >
         <div
           className="inline-flex items-center space-x-2"
@@ -106,22 +113,29 @@ const Todo = ({
               color: todos.todoId === id ? 'var(--main-color)' : '',
             }}
           >
-            <button onClick={onClick} style={{ textAlign: 'left' }}>
+            <button
+              onClick={onClick}
+              style={{
+                textAlign: 'left',
+              }}
+            >
               {title}
             </button>
           </div>
         </div>
         <div style={{ display: 'flex' }}>
-          <div className={`text-slate-500 px-5`}>
+          <div className={`text-slate-500 px-5`} style={{ paddingLeft: '0' }}>
             {performCount} / {planCount}
           </div>
           <button onClick={handleTodoDelete}>
             <BsTrash3 />
           </button>
           <button
-            className={`text-slate-500 px-2`}
             onClick={handleTodoDetail}
             disabled={status === 'DONE'}
+            style={{
+              padding: todos.todoId === id ? '0 0.3rem 0 0.5rem' : '0 0.5rem',
+            }}
           >
             <BsPencil />
           </button>

--- a/app-client/src/components/Todos/TodoList.tsx
+++ b/app-client/src/components/Todos/TodoList.tsx
@@ -32,7 +32,7 @@ const TodoList = () => {
 
   return (
     <div
-      className="max-w-lg mx-auto bg-white p-4 rounded-xl shadow shadow-slate-300"
+      className="max-w-lg mx-auto bg-white rounded-xl shadow shadow-slate-300"
       style={{ width: '100%' }}
     >
       <div


### PR DESCRIPTION
#281 

기존에는 

<img width="545" alt="image" src="https://github.com/growth-ring/taskgrow/assets/116357790/3bd75556-a5c7-4e79-9ebf-282c2f926ab9">

선택된 할 일의 텍스트만 파란색으로 보이도록 했었다.

**하지만 색깔만으로 표시하는건 좋지 않다.
색약이 있으신 분들은 구별하기 어렵기 때문이다.**
그래서 색깔말고도 구분되는 걸 추가하기 위해 border로도 추가로 표시하여 모양과 색깔 모두로 구분 될 수 있도록 개선함.

<img width="538" alt="image" src="https://github.com/growth-ring/taskgrow/assets/116357790/fd2dd56d-3422-4240-885a-59ba738606fd">

