### PR TITLE
[Frontend] 빈 칸은 할 일 추가될 수 없도록 하라

### DIFF
--- a/app-client/src/components/Todos/AddTodo.tsx
+++ b/app-client/src/components/Todos/AddTodo.tsx
@@ -31,6 +31,10 @@ const AddTodo = () => {
   const handleAddTodo = async (e: React.SyntheticEvent) => {
     e.preventDefault();
 
+    if (todo.trim() === '') {
+      return alert('할 일을 입력해주세요');
+    }
+
     if (+planCount > 0 && +planCount <= 20) {
       if (isGuest()) {
         const newTodo = {


### PR DESCRIPTION
아무 할 일을 입력하지 않고 엔터를 누르면, 입력해야 된다고 뜨지만 + 버튼을 누르면 아무 텍스트가 없는 할 일이 등록이 됨

+ 버튼을 누르면 무조건 추가되는 현상, 빈 칸이 추가되는 현상은 alert창으로 '할 일을 입력해주세요' 창이 뜨고 추가되지 않도록 수정했습니다.