### PR TITLE
[Frontend] 할 일 텍스트 위에만 커서 활성화하라

### DIFF
--- a/app-client/src/components/Todos/Todo.tsx
+++ b/app-client/src/components/Todos/Todo.tsx
@@ -83,9 +83,9 @@ const Todo = ({
           status === 'DONE' ? 'border-l-transparent' : 'border-l-indigo-300'
         } ${
           status === 'DONE'
-            ? 'color-main-colorbg-gradient-to-r from-transparent to-transparent hover:from-slate-100'
-            : 'bg-gradient-to-r from-indigo-100 to-transparent hover:from-indigo-200'
-        } transition ease-linear duration-150 cursor-pointer`}
+            ? 'color-main-colorbg-gradient-to-r from-transparent to-transparent'
+            : 'bg-gradient-to-r from-indigo-100 to-transparent'
+        } transition ease-linear duration-150`}
         style={{
           display: 'flex',
           width: '100%',


### PR DESCRIPTION
커서 영역 불확실한 현상 수정

<img width="535" alt="image" src="https://github.com/growth-ring/taskgrow/assets/116357790/180015a8-8a52-4444-bb51-ca6abdc79a49">

글씨 바깥에 마우스를 가져다 대면 누룰 수 있는 것처럼 나오는데 눌러도 아무런 반응이 없음.
정확히 텍스트 영역을 눌러야 클릭이 됨


텍스트 외의 영역은 커서 비활성화로 수정