### PR TITLE
[Frontend] 계획 뽀모도로라고 대상 구체화하여 안내하라

### DIFF
--- a/app-client/src/components/Todos/AddTodo.tsx
+++ b/app-client/src/components/Todos/AddTodo.tsx
@@ -62,7 +62,7 @@ const AddTodo = () => {
     } else if (+planCount <= 0) {
       alert('1 이상의 숫자를 넣어주세요');
     } else {
-      alert('뽀모도로는 최대 20개까지 가능합니다');
+      alert('계획 뽀모도로는 최대 20개까지 가능합니다');
     }
   };
 

--- a/app-client/src/components/Todos/TodoDetail.tsx
+++ b/app-client/src/components/Todos/TodoDetail.tsx
@@ -161,8 +161,8 @@ const TodoDetail = ({
                 />
               </div>
               <div className="py-2 text-gray font-thin text-sm">
-                뽀모도로는 최대 20개까지 가능합니다 <br />
-                이미 시작한 것은 뽀모도로 개수 수정이 불가능합니다
+                계획 뽀모도로는 최대 20개까지 가능합니다 <br />
+                이미 시작한 것은 계획 뽀모도로 개수 수정이 불가능합니다
               </div>
               <div className="flex justify-end mt-6 ">
                 <button


### PR DESCRIPTION
기존 : 뽀모도로는 최대 20개까지 가능합니다
변경 후: 계획 뽀모도로는 최대 20개까지 가능합니다

와 같이 '뽀모도로'로 안내되어 있는 텍스트를 '계획 뽀모도로'로 구체화해서 변경