### PR TITLE
[Backend] 투두 생성시 카테고리를 지정할 수 있다

### DIFF
--- a/app-server/src/main/java/com/growth/task/category/exception/CategoryNotFoundException.java
+++ b/app-server/src/main/java/com/growth/task/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.growth.task.category.exception;
+
+import com.growth.task.global.error.exception.EntityNotFoundException;
+
+public class CategoryNotFoundException extends EntityNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "카테고리를 찾을 수 없습니다.";
+
+    public CategoryNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/app-server/src/main/java/com/growth/task/category/service/CategoryRetrieveService.java
+++ b/app-server/src/main/java/com/growth/task/category/service/CategoryRetrieveService.java
@@ -2,6 +2,7 @@ package com.growth.task.category.service;
 
 import com.growth.task.category.domain.Category;
 import com.growth.task.category.dto.CategoryResponse;
+import com.growth.task.category.exception.CategoryNotFoundException;
 import com.growth.task.category.repository.CategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,5 +23,11 @@ public class CategoryRetrieveService {
         return categories.stream()
                 .map(CategoryResponse::of)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Category getCategory(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new CategoryNotFoundException());
     }
 }

--- a/app-server/src/main/java/com/growth/task/todo/application/TodoCategoryAddService.java
+++ b/app-server/src/main/java/com/growth/task/todo/application/TodoCategoryAddService.java
@@ -1,0 +1,35 @@
+package com.growth.task.todo.application;
+
+import com.growth.task.category.domain.Category;
+import com.growth.task.category.service.CategoryRetrieveService;
+import com.growth.task.todo.domain.TodoCategory;
+import com.growth.task.todo.domain.Todos;
+import com.growth.task.todo.repository.TodoCategoryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class TodoCategoryAddService {
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final CategoryRetrieveService categoryRetrieveService;
+
+    public TodoCategoryAddService(
+            TodoCategoryRepository todoCategoryRepository,
+            CategoryRetrieveService categoryRetrieveService
+    ) {
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.categoryRetrieveService = categoryRetrieveService;
+    }
+
+    @Transactional
+    public TodoCategory save(Todos todo, Long categoryId) {
+        if (categoryId == null) {
+            log.debug("주어진 카테고리가 없습니다.");
+            return null;
+        }
+        Category category = categoryRetrieveService.getCategory(categoryId);
+        return todoCategoryRepository.save(new TodoCategory(todo, category));
+    }
+}

--- a/app-server/src/main/java/com/growth/task/todo/application/TodoWithRelatedAddService.java
+++ b/app-server/src/main/java/com/growth/task/todo/application/TodoWithRelatedAddService.java
@@ -3,6 +3,7 @@ package com.growth.task.todo.application;
 import com.growth.task.pomodoro.domain.Pomodoros;
 import com.growth.task.pomodoro.dto.response.PomodoroAddResponse;
 import com.growth.task.pomodoro.service.PomodoroAddService;
+import com.growth.task.todo.domain.TodoCategory;
 import com.growth.task.todo.domain.Todos;
 import com.growth.task.todo.dto.composite.TodoAndPomodoroAddRequest;
 import com.growth.task.todo.dto.composite.TodoAndPomodoroAddResponse;
@@ -15,22 +16,26 @@ public class TodoWithRelatedAddService {
 
     private final TodoAddService todoAddService;
     private final PomodoroAddService pomodoroAddService;
+    private final TodoCategoryAddService todoCategoryAddService;
 
     public TodoWithRelatedAddService(
             TodoAddService todoAddService,
-            PomodoroAddService pomodoroAddService
-    ) {
+            PomodoroAddService pomodoroAddService,
+            TodoCategoryAddService todoCategoryAddService) {
         this.todoAddService = todoAddService;
         this.pomodoroAddService = pomodoroAddService;
+        this.todoCategoryAddService = todoCategoryAddService;
     }
 
     @Transactional
     public TodoAndPomodoroAddResponse saveWithRelated(TodoAndPomodoroAddRequest todoAndPomodoroAddRequest) {
         Todos todos = todoAddService.save(todoAndPomodoroAddRequest.getTodoAddRequest());
         Pomodoros pomodoros = pomodoroAddService.save(todoAndPomodoroAddRequest.getPomodoroAddRequest(), todos);
+        TodoCategory todoCategory = todoCategoryAddService.save(todos, todoAndPomodoroAddRequest.getCategoryId());
 
         TodoAddResponse todoAddResponse = new TodoAddResponse(todos);
         PomodoroAddResponse pomodoroAddResponse = new PomodoroAddResponse(pomodoros);
-        return new TodoAndPomodoroAddResponse(todoAddResponse, pomodoroAddResponse);
+
+        return new TodoAndPomodoroAddResponse(todoAddResponse, pomodoroAddResponse, todoCategory);
     }
 }

--- a/app-server/src/main/java/com/growth/task/todo/domain/TodoCategory.java
+++ b/app-server/src/main/java/com/growth/task/todo/domain/TodoCategory.java
@@ -1,0 +1,36 @@
+package com.growth.task.todo.domain;
+
+import com.growth.task.category.domain.Category;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+@Entity
+public class TodoCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_id", referencedColumnName = "todo_id")
+    private Todos todos;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", referencedColumnName = "id")
+    private Category category;
+
+    public TodoCategory(Todos todos, Category category) {
+        this.todos = todos;
+        this.category = category;
+    }
+}

--- a/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddRequest.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddRequest.java
@@ -27,10 +27,11 @@ public class TodoAndPomodoroAddRequest {
             @JsonProperty("taskId") Long taskId,
             @JsonProperty("todo") String todo,
             @JsonProperty("orderNo") int orderNo,
+            @JsonProperty("categoryId") Long categoryId,
             @JsonProperty("performCount") int performCount,
             @JsonProperty("planCount") int planCount
     ) {
-        this.todoAddRequest = new TodoAddRequest(taskId, todo, orderNo);
+        this.todoAddRequest = new TodoAddRequest(taskId, todo, orderNo, categoryId);
         this.pomodoroAddRequest = new PomodoroAddRequest(performCount, planCount);
     }
 
@@ -50,6 +51,10 @@ public class TodoAndPomodoroAddRequest {
 
     public int getOrderNo() {
         return todoAddRequest.getOrderNo();
+    }
+
+    public Long getCategoryId() {
+        return todoAddRequest.getCategoryId();
     }
 
     public int getPerformCount() {

--- a/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddResponse.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/composite/TodoAndPomodoroAddResponse.java
@@ -1,6 +1,7 @@
 package com.growth.task.todo.dto.composite;
 
 import com.growth.task.pomodoro.dto.response.PomodoroAddResponse;
+import com.growth.task.todo.domain.TodoCategory;
 import com.growth.task.todo.dto.response.TodoAddResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,26 +12,38 @@ public class TodoAndPomodoroAddResponse {
     private Long taskId;
     private String todo;
     private String status;
+    private String category;
     private int performCount;
     private int planCount;
     private int orderNo;
 
     @Builder
-    public TodoAndPomodoroAddResponse(Long todoId, Long taskId, String todo, String status, int performCount, int planCount, int orderNo) {
+    public TodoAndPomodoroAddResponse(
+            Long todoId,
+            Long taskId,
+            String todo,
+            String status,
+            String category,
+            int performCount,
+            int planCount,
+            int orderNo
+    ) {
         this.todoId = todoId;
         this.taskId = taskId;
         this.todo = todo;
         this.status = status;
+        this.category = category;
         this.performCount = performCount;
         this.planCount = planCount;
         this.orderNo = orderNo;
     }
 
-    public TodoAndPomodoroAddResponse(TodoAddResponse todoAddResponse, PomodoroAddResponse pomodoroAddResponse) {
+    public TodoAndPomodoroAddResponse(TodoAddResponse todoAddResponse, PomodoroAddResponse pomodoroAddResponse, TodoCategory category) {
         this.todoId = todoAddResponse.getTodoId();
         this.taskId = todoAddResponse.getTaskId();
         this.todo = todoAddResponse.getTodo();
         this.status = todoAddResponse.getStatus().toString(); // Enum을 문자열로 변환
+        this.category = category != null ? category.getCategory().getName() : null;
         this.performCount = pomodoroAddResponse.getPerformCount();
         this.planCount = pomodoroAddResponse.getPlanCount();
         this.orderNo = todoAddResponse.getOrderNo();

--- a/app-server/src/main/java/com/growth/task/todo/dto/request/TodoAddRequest.java
+++ b/app-server/src/main/java/com/growth/task/todo/dto/request/TodoAddRequest.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * Todo 생성 요청
+ * 투두 생성 요청
  */
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -24,11 +24,19 @@ public class TodoAddRequest {
     @Min(value = 1, message = "1 이상이어야 합니다.")
     private int orderNo;
 
+    private Long categoryId;
+
     @Builder
-    public TodoAddRequest(Long taskId, String todo, int orderNo) {
+    public TodoAddRequest(
+            Long taskId,
+            String todo,
+            int orderNo,
+            Long categoryId
+    ) {
         this.taskId = taskId;
         this.todo = todo;
         this.orderNo = orderNo;
+        this.categoryId = categoryId;
     }
 
     public Todos toEntity(Tasks tasks) {

--- a/app-server/src/main/java/com/growth/task/todo/repository/TodoCategoryRepository.java
+++ b/app-server/src/main/java/com/growth/task/todo/repository/TodoCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.growth.task.todo.repository;
+
+import com.growth.task.todo.domain.TodoCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long> {
+}

--- a/app-server/src/test/java/com/growth/task/todo/application/TodoCategoryAddServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/application/TodoCategoryAddServiceTest.java
@@ -1,0 +1,104 @@
+package com.growth.task.todo.application;
+
+import com.growth.task.category.domain.Category;
+import com.growth.task.category.service.CategoryRetrieveService;
+import com.growth.task.task.domain.Tasks;
+import com.growth.task.todo.domain.TodoCategory;
+import com.growth.task.todo.domain.Todos;
+import com.growth.task.todo.enums.Status;
+import com.growth.task.todo.repository.TodoCategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TodoCategoryAddServiceTest {
+    private TodoCategoryAddService todoCategoryAddService;
+
+    @Mock
+    private TodoCategoryRepository todoCategoryRepository;
+    @Mock
+    private CategoryRetrieveService categoryRetrieveService;
+
+    @BeforeEach
+    void setUp() {
+        todoCategoryAddService = new TodoCategoryAddService(todoCategoryRepository, categoryRetrieveService);
+    }
+
+    @Nested
+    @DisplayName("save")
+    class Describe_save {
+        @Nested
+        @DisplayName("투두와 카테고리 id가 주어지면")
+        class Context_with_todo_and_category {
+            private Todos givenTodo = Todos.builder()
+                    .task(mock(Tasks.class))
+                    .todo("인간관계론 읽기")
+                    .status(Status.READY)
+                    .orderNo(1)
+                    .build();
+            private Category category = Category.builder()
+                    .name("독서하기")
+                    .build();
+
+            @BeforeEach
+            void prepare() {
+                ReflectionTestUtils.setField(category, "id", 1L);
+
+                given(categoryRetrieveService.getCategory(1L))
+                        .willReturn(category);
+                given(todoCategoryRepository.save(any()))
+                        .willReturn(new TodoCategory(givenTodo, category));
+            }
+
+            @Test
+            @DisplayName("투두 카테고리 연관 관계를 저장한다")
+            void it_save() {
+                TodoCategory actual = todoCategoryAddService.save(givenTodo, category.getId());
+
+                assertAll(
+                        () -> assertThat(actual.getTodos().getTodo()).isEqualTo(givenTodo.getTodo()),
+                        () -> assertThat(actual.getTodos().getStatus()).isEqualTo(givenTodo.getStatus()),
+                        () -> assertThat(actual.getTodos().getOrderNo()).isEqualTo(givenTodo.getOrderNo()),
+                        () -> assertThat(actual.getCategory().getName()).isEqualTo(category.getName()),
+                        () -> verify(categoryRetrieveService, times(1)).getCategory(any())
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("카테고리 id가 주어지지 않으면")
+        class Context_without_category_id {
+            private Todos givenTodo = Todos.builder()
+                    .task(mock(Tasks.class))
+                    .todo("인간관계론 읽기")
+                    .status(Status.READY)
+                    .orderNo(1)
+                    .build();
+
+            @Test
+            @DisplayName("아무 일도 하지 않고 null을 리턴한다")
+            void it_nothing_and_return_null() {
+                TodoCategory actual = todoCategoryAddService.save(givenTodo, null);
+
+                assertAll(
+                        () -> assertThat(actual).isNull(),
+                        () -> verify(categoryRetrieveService, times(0)).getCategory(any())
+                );
+            }
+        }
+    }
+}

--- a/app-server/src/test/java/com/growth/task/todo/controller/TodoAddControllerTest.java
+++ b/app-server/src/test/java/com/growth/task/todo/controller/TodoAddControllerTest.java
@@ -3,6 +3,8 @@ package com.growth.task.todo.controller;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.growth.task.category.domain.Category;
+import com.growth.task.category.repository.CategoryRepository;
 import com.growth.task.pomodoro.dto.request.PomodoroAddRequest;
 import com.growth.task.pomodoro.repository.PomodorosRepository;
 import com.growth.task.task.domain.Tasks;
@@ -10,6 +12,7 @@ import com.growth.task.task.repository.TasksRepository;
 import com.growth.task.todo.dto.composite.TodoAndPomodoroAddRequest;
 import com.growth.task.todo.dto.request.TodoAddRequest;
 import com.growth.task.todo.enums.Status;
+import com.growth.task.todo.repository.TodoCategoryRepository;
 import com.growth.task.todo.repository.TodosRepository;
 import com.growth.task.user.domain.Users;
 import com.growth.task.user.domain.UsersRepository;
@@ -44,6 +47,7 @@ class TodoAddControllerTest {
     public static final String TODO = "디자인패턴의 아름다움 스터디";
     public static final int PERFORM_COUNT = 2;
     public static final int PLAN_COUNT = 5;
+    public static final String CATEGORY_STUDY = "스터디";
     @Autowired
     private TodosRepository todosRepository;
     @Autowired
@@ -52,6 +56,10 @@ class TodoAddControllerTest {
     private TasksRepository tasksRepository;
     @Autowired
     private UsersRepository usersRepository;
+    @Autowired
+    private TodoCategoryRepository todoCategoryRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     @Autowired
@@ -71,6 +79,8 @@ class TodoAddControllerTest {
 
     @AfterEach
     void cleanUp() {
+        todoCategoryRepository.deleteAll();
+        categoryRepository.deleteAll();
         pomodorosRepository.deleteAll();
         todosRepository.deleteAll();
         tasksRepository.deleteAll();
@@ -142,6 +152,61 @@ class TodoAddControllerTest {
                         .andExpect(jsonPath("$.performCount").value(PERFORM_COUNT))
                         .andExpect(jsonPath("$.planCount").value(PLAN_COUNT))
                         .andExpect(jsonPath("$.orderNo").value(1))
+                        .andExpect(jsonPath("$.category").doesNotExist())
+                ;
+            }
+        }
+
+        @DisplayName("존재하는 Task id와 생성 정보, 카테고리가 주어지면")
+        @Nested
+        class Context_with_exist_task_id_and_request_and_category {
+            private Tasks task;
+            private TodoAndPomodoroAddRequest request;
+
+            @BeforeEach
+            void setTask() {
+                task = tasksRepository.save(Tasks.builder()
+                        .user(user)
+                        .taskDate(LOCAL_DATE)
+                        .build());
+                Category category = categoryRepository.save(
+                        Category.builder()
+                                .name(CATEGORY_STUDY)
+                                .build()
+                );
+
+                TodoAddRequest todoAddRequest = TodoAddRequest.builder()
+                        .taskId(task.getTaskId())
+                        .todo(TODO)
+                        .orderNo(1)
+                        .categoryId(category.getId())
+                        .build();
+
+                PomodoroAddRequest pomodoroAddRequest = PomodoroAddRequest.builder()
+                        .performCount(PERFORM_COUNT)
+                        .planCount(PLAN_COUNT)
+                        .build();
+
+                request = TodoAndPomodoroAddRequest.builder()
+                        .todoAddRequest(todoAddRequest)
+                        .pomodoroAddRequest(pomodoroAddRequest)
+                        .build();
+            }
+
+            @Test
+            @DisplayName("201을 응답한다")
+            void it_response_201() throws Exception {
+                final ResultActions resultActions = subject(request);
+
+                resultActions.andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.todoId").exists())
+                        .andExpect(jsonPath("$.taskId").exists())
+                        .andExpect(jsonPath("$.todo").value(TODO))
+                        .andExpect(jsonPath("$.status").value(Status.READY.name()))
+                        .andExpect(jsonPath("$.performCount").value(PERFORM_COUNT))
+                        .andExpect(jsonPath("$.planCount").value(PLAN_COUNT))
+                        .andExpect(jsonPath("$.orderNo").value(1))
+                        .andExpect(jsonPath("$.category").value(CATEGORY_STUDY))
                 ;
             }
         }


### PR DESCRIPTION
issue no. #317 

투두 생성시 카테고리 Id를 넘기면 카테고리가 저장된다. 
카테고리 id를 넘기지 않으면 카테고리 저장되지 않는다. 

###  카테고리 저장시
```json 
{
  "taskId": 1,
  "todo": "인강듣기",
  "orderNo": 3,
  "categoryId": 1,
  "performCount": 0,
  "planCount": 3
}
```
### 카테고리 미저장시
- null을 넘김
```json
{
    "taskId": 1,
    "todo": "인강듣기",
    "orderNo": 3,
    "categoryId": null,
    "performCount": 0,
    "planCount": 3
  }
```
- 해당 항목을 넘기지 않음
```json
{
  "taskId": 1,
  "todo": "인강듣기",
  "orderNo": 3,
  "performCount": 0,
  "planCount": 3
}

```

응답에는 카테고리명이 표시된다.
- 카테고리가 있는 경우
```json
{
  "todoId": 3,
  "taskId": 1,
  "todo": "인강듣기",
  "status": "READY",
  "category": "공부",
  "performCount": 0,
  "planCount": 3,
  "orderNo": 3
}
```

- 카테고리가 없는 경우 
```json
{
  "todoId": 3,
  "taskId": 1,
  "todo": "인강듣기",
  "status": "READY",
  "category": null,
  "performCount": 0,
  "planCount": 3,
  "orderNo": 3
}
```