### PR TITLE
[Backend] 카테고리 등록 버그 수정 및 리팩터링

### DIFF
--- a/app-server/src/main/java/com/growth/task/category/dto/CategoryRequest.java
+++ b/app-server/src/main/java/com/growth/task/category/dto/CategoryRequest.java
@@ -23,7 +23,7 @@ public class CategoryRequest {
 
     public Category toEntity() {
         return Category.builder()
-                .name(name)
+                .name(removeSpace(name))
                 .build();
     }
 

--- a/app-server/src/main/java/com/growth/task/category/exception/CategoryAlreadyExistsException.java
+++ b/app-server/src/main/java/com/growth/task/category/exception/CategoryAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.growth.task.category.exception;
+
+import com.growth.task.global.error.exception.AlreadyExistsException;
+
+public class CategoryAlreadyExistsException extends AlreadyExistsException {
+
+    private static final String DEFAULT_MESSAGE = "이미 존재하는 카테고리입니다.";
+
+    public CategoryAlreadyExistsException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/app-server/src/main/java/com/growth/task/category/repository/CategoryRepository.java
+++ b/app-server/src/main/java/com/growth/task/category/repository/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.growth.task.category.repository;
 import com.growth.task.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
 }

--- a/app-server/src/main/java/com/growth/task/category/service/CategoryAddService.java
+++ b/app-server/src/main/java/com/growth/task/category/service/CategoryAddService.java
@@ -3,6 +3,7 @@ package com.growth.task.category.service;
 import com.growth.task.category.domain.Category;
 import com.growth.task.category.dto.CategoryRequest;
 import com.growth.task.category.dto.CategoryResponse;
+import com.growth.task.category.exception.CategoryAlreadyExistsException;
 import com.growth.task.category.repository.CategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,11 @@ public class CategoryAddService {
 
     @Transactional
     public CategoryResponse save(CategoryRequest request) {
+        categoryRepository.findByName(request.getName())
+                .ifPresent(it -> {
+                    throw new CategoryAlreadyExistsException();
+                });
+
         Category category = categoryRepository.save(request.toEntity());
         return CategoryResponse.of(category);
     }

--- a/app-server/src/test/java/com/growth/task/category/service/CategoryAddServiceTest.java
+++ b/app-server/src/test/java/com/growth/task/category/service/CategoryAddServiceTest.java
@@ -3,6 +3,7 @@ package com.growth.task.category.service;
 import com.growth.task.category.domain.Category;
 import com.growth.task.category.dto.CategoryRequest;
 import com.growth.task.category.dto.CategoryResponse;
+import com.growth.task.category.exception.CategoryAlreadyExistsException;
 import com.growth.task.category.repository.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -44,6 +48,8 @@ class CategoryAddServiceTest {
 
             @BeforeEach
             void prepare() {
+                given(categoryRepository.findByName(any()))
+                        .willReturn(Optional.empty());
                 given(categoryRepository.save(any()))
                         .willReturn(givenCategory);
             }
@@ -54,6 +60,30 @@ class CategoryAddServiceTest {
                 CategoryResponse category = categoryAddService.save(request);
 
                 assertThat(category.getName()).isEqualTo(NAME);
+            }
+        }
+
+        @DisplayName("이미 존재하는 카테고리 명이 주어지면")
+        @Nested
+        class Context_with_already_existing_name {
+            private CategoryRequest request = CategoryRequest.builder()
+                    .name(NAME)
+                    .build();
+            private Category givenCategory = Category.builder()
+                    .name(NAME)
+                    .build();
+
+            @BeforeEach
+            void prepare() {
+                given(categoryRepository.findByName(any()))
+                        .willReturn(Optional.of(givenCategory));
+            }
+
+            @DisplayName("예외를 던진다")
+            @Test
+            void it_throw_exception() {
+                assertThatThrownBy(() -> categoryAddService.save(request))
+                        .isInstanceOf(CategoryAlreadyExistsException.class);
             }
         }
     }


### PR DESCRIPTION
issue no. #326 , #325 

카테고리 등록시 공백제거가 안되는 버그 수정
카테고리 등록시 이미 등록된 카테고리 명인 경우 예외 처리
기존에는 DB의 제약 조건으로 예외를 던졌으나, DB에서 해당 카테고리명으로 카테고리를 조회하여 이미 존재하는지 확인한다. 